### PR TITLE
ci: persist android-test logs by run-id with retention cleanup

### DIFF
--- a/.github/scripts/android-instrumentation.sh
+++ b/.github/scripts/android-instrumentation.sh
@@ -3,40 +3,52 @@
 set -euo pipefail
 
 chmod +x ./gradlew
-mkdir -p artifacts/android-test
 INSTRUMENTATION_SMOKE_TIMEOUT_SEC=120
 PM_SETTLE_ATTEMPTS=10
 PM_SETTLE_SLEEP_SEC=3
+ARTIFACT_BASE_DIR="${ARTIFACT_BASE_DIR:-artifacts/android-test}"
+ANDROID_TEST_FLAVOR="${ANDROID_TEST_FLAVOR:-unknown}"
+
+mkdir -p "${ARTIFACT_BASE_DIR}"
 
 EMULATOR_SERIAL="$(adb devices | awk '/^emulator-[0-9]+[[:space:]]+device$/ {print $1; exit}')"
 if [ -z "${EMULATOR_SERIAL}" ]; then
   EMULATOR_SERIAL="emulator-5554"
 fi
 
+{
+  echo "android_test_flavor=${ANDROID_TEST_FLAVOR}"
+  echo "artifact_base_dir=${ARTIFACT_BASE_DIR}"
+  echo "emulator_serial=${EMULATOR_SERIAL}"
+  echo "github_run_number=${GITHUB_RUN_NUMBER:-}"
+  echo "github_run_attempt=${GITHUB_RUN_ATTEMPT:-}"
+  echo "github_sha=${GITHUB_SHA:-}"
+} > "${ARTIFACT_BASE_DIR}/run-context.txt"
+
 collect_diagnostics() {
   local suffix="$1"
-  adb devices -l > "artifacts/android-test/adb-devices-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell getprop > "artifacts/android-test/getprop-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell pm list instrumentation > "artifacts/android-test/pm-list-instrumentation-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell cmd package list packages com.example.orgclock > "artifacts/android-test/package-list-orgclock-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell dumpsys activity processes > "artifacts/android-test/dumpsys-activity-processes-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell dumpsys package com.example.orgclock > "artifacts/android-test/dumpsys-package-orgclock-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell dumpsys package com.example.orgclock.test > "artifacts/android-test/dumpsys-package-orgclock-test-${suffix}.txt" || true
-  adb -s "${EMULATOR_SERIAL}" shell logcat -d -v time > "artifacts/android-test/logcat-${suffix}.txt" || true
+  adb devices -l > "${ARTIFACT_BASE_DIR}/adb-devices-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell getprop > "${ARTIFACT_BASE_DIR}/getprop-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell pm list instrumentation > "${ARTIFACT_BASE_DIR}/pm-list-instrumentation-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell cmd package list packages com.example.orgclock > "${ARTIFACT_BASE_DIR}/package-list-orgclock-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell dumpsys activity processes > "${ARTIFACT_BASE_DIR}/dumpsys-activity-processes-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell dumpsys package com.example.orgclock > "${ARTIFACT_BASE_DIR}/dumpsys-package-orgclock-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell dumpsys package com.example.orgclock.test > "${ARTIFACT_BASE_DIR}/dumpsys-package-orgclock-test-${suffix}.txt" || true
+  adb -s "${EMULATOR_SERIAL}" shell logcat -d -v time > "${ARTIFACT_BASE_DIR}/logcat-${suffix}.txt" || true
   if adb -s "${EMULATOR_SERIAL}" shell pm list instrumentation | grep -q "com.example.orgclock.test/androidx.test.runner.AndroidJUnitRunner"; then
-    local smoke_log_path="artifacts/android-test/instrumentation-smoke-${suffix}.txt"
+    local smoke_log_path="${ARTIFACT_BASE_DIR}/instrumentation-smoke-${suffix}.txt"
     set +e
     timeout "${INSTRUMENTATION_SMOKE_TIMEOUT_SEC}" adb -s "${EMULATOR_SERIAL}" shell am instrument -w -m com.example.orgclock.test/androidx.test.runner.AndroidJUnitRunner > "${smoke_log_path}" 2>&1
     local smoke_status=$?
     set -e
 
     if [ "${smoke_status}" -eq 124 ]; then
-      echo "Instrumentation smoke timed out after ${INSTRUMENTATION_SMOKE_TIMEOUT_SEC}s" > "artifacts/android-test/instrumentation-smoke-timeout-${suffix}.txt"
+      echo "Instrumentation smoke timed out after ${INSTRUMENTATION_SMOKE_TIMEOUT_SEC}s" > "${ARTIFACT_BASE_DIR}/instrumentation-smoke-timeout-${suffix}.txt"
     elif [ "${smoke_status}" -ne 0 ]; then
-      echo "Instrumentation smoke exited with status ${smoke_status}" > "artifacts/android-test/instrumentation-smoke-failure-${suffix}.txt"
+      echo "Instrumentation smoke exited with status ${smoke_status}" > "${ARTIFACT_BASE_DIR}/instrumentation-smoke-failure-${suffix}.txt"
     fi
   else
-    echo "Instrumentation not installed for com.example.orgclock.test" > "artifacts/android-test/instrumentation-not-installed-${suffix}.txt"
+    echo "Instrumentation not installed for com.example.orgclock.test" > "${ARTIFACT_BASE_DIR}/instrumentation-not-installed-${suffix}.txt"
   fi
 }
 
@@ -103,7 +115,7 @@ ensure_instrumentation_installed() {
 run_gradle_logged() {
   local suffix="$1"
   shift
-  local log_path="artifacts/android-test/gradle-${suffix}.log"
+  local log_path="${ARTIFACT_BASE_DIR}/gradle-${suffix}.log"
   set +e
   ./gradlew --stacktrace --info "$@" 2>&1 | tee "${log_path}"
   local status=${PIPESTATUS[0]}

--- a/.github/scripts/cleanup-ci-logs.sh
+++ b/.github/scripts/cleanup-ci-logs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASE_DIR="${1:-artifacts/ci/android-test}"
+KEEP_RUNS="${2:-20}"
+
+if [ ! -d "${BASE_DIR}" ]; then
+  exit 0
+fi
+
+if ! [[ "${KEEP_RUNS}" =~ ^[0-9]+$ ]]; then
+  echo "KEEP_RUNS must be a non-negative integer: ${KEEP_RUNS}" >&2
+  exit 1
+fi
+
+mapfile -t run_dirs < <(find "${BASE_DIR}" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+
+if [ "${#run_dirs[@]}" -le "${KEEP_RUNS}" ]; then
+  exit 0
+fi
+
+for run_dir in "${run_dirs[@]:${KEEP_RUNS}}"; do
+  rm -rf "${BASE_DIR}/${run_dir}"
+done

--- a/.github/workflows/android-instrumentation.yml
+++ b/.github/workflows/android-instrumentation.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 45
     env:
       GRADLE_USER_HOME: /home/runner/.gradle
+      ANDROID_TEST_LOG_KEEP_RUNS: 20
 
     steps:
       - name: Checkout
@@ -34,8 +35,28 @@ jobs:
           java-version: "17"
           cache: gradle
 
+      - name: Prepare run-id and artifact directory
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA::8}"
+          SHA_EPOCH="$(git show -s --format=%ct "$GITHUB_SHA")"
+          UTC_TS="$(date -u -d "@${SHA_EPOCH}" +%Y%m%dT%H%M%SZ)"
+          RUN_ID="${UTC_TS}_r${GITHUB_RUN_NUMBER}_a${GITHUB_RUN_ATTEMPT}_sha${SHORT_SHA}"
+          ARTIFACT_BASE_DIR="artifacts/ci/android-test/${RUN_ID}/api34"
+          echo "RUN_ID=${RUN_ID}" >> "$GITHUB_ENV"
+          echo "ARTIFACT_BASE_DIR=${ARTIFACT_BASE_DIR}" >> "$GITHUB_ENV"
+          mkdir -p "${ARTIFACT_BASE_DIR}"
+
+      - name: Cleanup old android-test run logs
+        run: |
+          set -euo pipefail
+          bash .github/scripts/cleanup-ci-logs.sh artifacts/ci/android-test "${ANDROID_TEST_LOG_KEEP_RUNS}"
+
       - name: Run instrumentation tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          ARTIFACT_BASE_DIR: ${{ env.ARTIFACT_BASE_DIR }}
+          ANDROID_TEST_FLAVOR: api34
         with:
           api-level: 34
           arch: x86_64
@@ -54,7 +75,7 @@ jobs:
             app/build/reports/androidTests
             app/build/outputs/androidTest-results
             app/build/outputs/logs
-            artifacts/android-test
+            ${{ env.ARTIFACT_BASE_DIR }}
             /tmp/android-runner
             /home/runner/.android/avd/*/emulator-user.log
 
@@ -65,6 +86,7 @@ jobs:
     timeout-minutes: 45
     env:
       GRADLE_USER_HOME: /home/runner/.gradle
+      ANDROID_TEST_LOG_KEEP_RUNS: 20
 
     steps:
       - name: Checkout
@@ -77,8 +99,28 @@ jobs:
           java-version: "17"
           cache: gradle
 
+      - name: Prepare run-id and artifact directory
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA::8}"
+          SHA_EPOCH="$(git show -s --format=%ct "$GITHUB_SHA")"
+          UTC_TS="$(date -u -d "@${SHA_EPOCH}" +%Y%m%dT%H%M%SZ)"
+          RUN_ID="${UTC_TS}_r${GITHUB_RUN_NUMBER}_a${GITHUB_RUN_ATTEMPT}_sha${SHORT_SHA}"
+          ARTIFACT_BASE_DIR="artifacts/ci/android-test/${RUN_ID}/api35"
+          echo "RUN_ID=${RUN_ID}" >> "$GITHUB_ENV"
+          echo "ARTIFACT_BASE_DIR=${ARTIFACT_BASE_DIR}" >> "$GITHUB_ENV"
+          mkdir -p "${ARTIFACT_BASE_DIR}"
+
+      - name: Cleanup old android-test run logs
+        run: |
+          set -euo pipefail
+          bash .github/scripts/cleanup-ci-logs.sh artifacts/ci/android-test "${ANDROID_TEST_LOG_KEEP_RUNS}"
+
       - name: Run instrumentation tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          ARTIFACT_BASE_DIR: ${{ env.ARTIFACT_BASE_DIR }}
+          ANDROID_TEST_FLAVOR: api35
         with:
           api-level: 35
           arch: x86_64
@@ -97,6 +139,6 @@ jobs:
             app/build/reports/androidTests
             app/build/outputs/androidTest-results
             app/build/outputs/logs
-            artifacts/android-test
+            ${{ env.ARTIFACT_BASE_DIR }}
             /tmp/android-runner
             /home/runner/.android/avd/*/emulator-user.log

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ local.properties
 
 # Log/OS Files
 *.log
+artifacts/ci/
 
 # Android Studio generated files and folders
 captures/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Android 端末上で org ファイルの見出しに対して clock 記録を行
   `docs/firebase-app-distribution-guide.md`
 - 手動スモークテスト手順  
   `docs/manual-smoke-test.md`
+- CI android-test ログ管理  
+  `docs/ci-android-test-log-management.md`
 - パフォーマンス計測手順  
   `docs/performance-benchmark.md`
 - 通知機能仕様  

--- a/docs/ci-android-test-log-management.md
+++ b/docs/ci-android-test-log-management.md
@@ -1,0 +1,77 @@
+# CI Android-Test ログ管理
+
+`android-test` の失敗調査を再現可能にするため、ログの命名規則と保存先を固定します。
+
+## 対象
+
+- GitHub Actions: `.github/workflows/android-instrumentation.yml`
+- Jobs: `android-test` (API 34), `android-test-api35` (API 35)
+- 収集元: `.github/scripts/android-instrumentation.sh` が出力する診断ログ
+
+## Run ID 仕様
+
+`<run-id>` は次の形式を使います。
+
+`<UTC時刻>_r<run_number>_a<run_attempt>_sha<short_sha>`
+
+例:
+
+`20260224T123045Z_r182_a1_sha1a2b3c4`
+
+構成要素:
+
+- `UTC時刻`: `YYYYMMDDTHHMMSSZ`
+- `run_number`: GitHub Actions `GITHUB_RUN_NUMBER`
+- `run_attempt`: GitHub Actions `GITHUB_RUN_ATTEMPT`
+- `short_sha`: `GITHUB_SHA` 先頭8文字
+
+## ディレクトリ規約
+
+保存ルート:
+
+`artifacts/ci/android-test/<run-id>/`
+
+APIごとのサブディレクトリ:
+
+- API 34: `artifacts/ci/android-test/<run-id>/api34/`
+- API 35: `artifacts/ci/android-test/<run-id>/api35/`
+
+この配下に `gradle-install-*.log`、`logcat-*.txt`、`pm-list-instrumentation-*.txt` などを保存します。
+
+## 運用ルール
+
+- 生ログは編集しない（切り出し・再整形しない）。
+- ログは Git にコミットしない（`.gitignore` で `artifacts/ci/` を除外）。
+- 比較調査時は run ディレクトリ単位で扱う。
+
+## Cleanup ルール
+
+- 保持本数方式: 最新 N run を保持し、それより古い run を削除。
+- CI の既定値: `ANDROID_TEST_LOG_KEEP_RUNS=20`
+- 実体: `.github/scripts/cleanup-ci-logs.sh`
+
+実行例:
+
+```bash
+bash .github/scripts/cleanup-ci-logs.sh artifacts/ci/android-test 20
+```
+
+## 手元調査での持ち込み
+
+CI から取得した `artifacts/android-test` 相当のファイル群は、次のように run 単位で配置します。
+
+1. `<run-id>` を決める。
+2. `artifacts/ci/android-test/<run-id>/api34/` または `api35/` を作る。
+3. 生ログをそのまま配置する。
+
+最低限必要なファイル:
+
+- `gradle-install-*.log`
+- `logcat-*.txt`
+
+推奨追加:
+
+- `adb-devices-*.txt`
+- `getprop-*.txt`
+- `pm-list-instrumentation-*.txt`
+- `dumpsys-package-orgclock*.txt`


### PR DESCRIPTION

  ## Summary
  Persist android instrumentation logs by run-id and API lane, with retention cleanup and docs.

  ## Changes
  - Add run-id based artifact layout under `artifacts/ci/android-test/<run-id>/api34|api35`
  - Pass `ARTIFACT_BASE_DIR` / `ANDROID_TEST_FLAVOR` to instrumentation script
  - Keep backward-compatible default (`artifacts/android-test`) for local script runs
  - Add retention cleanup script: `.github/scripts/cleanup-ci-logs.sh` (default keep 20 runs)
  - Add docs: `docs/ci-android-test-log-management.md`
  - Update `README.md` docs links
  - Ignore persisted CI log root via `.gitignore` (`artifacts/ci/`)

  ## Validation
  - `bash -n .github/scripts/android-instrumentation.sh`
  - `bash -n .github/scripts/cleanup-ci-logs.sh`

  ## Notes
  - No behavior change to app runtime code.
  - CI runtime validation will be confirmed by the next `android-instrumentation` workflow run.