### PR TITLE
fix: remove stale clock display after stop by trusting optimistic UI

### DIFF
--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
@@ -160,6 +161,7 @@ fun OrgClockScreen(
                 onLongPressL1 = { onAction(OrgClockUiAction.OpenCreateL2Dialog(it)) },
                 onCollapseAll = { onAction(OrgClockUiAction.CollapseAll) },
                 onExpandAll = { onAction(OrgClockUiAction.ExpandAll) },
+                onRefresh = { onAction(OrgClockUiAction.RefreshHeadings) },
                 onLongPressL2 = { onAction(OrgClockUiAction.OpenHistory(it)) },
                 onOpenCreateL1 = { onAction(OrgClockUiAction.OpenCreateL1Dialog) },
                 onOpenFilePicker = { onAction(OrgClockUiAction.OpenFilePicker) },
@@ -333,6 +335,7 @@ private fun HeadingListScreen(
     onLongPressL1: (HeadingViewItem) -> Unit,
     onCollapseAll: () -> Unit,
     onExpandAll: () -> Unit,
+    onRefresh: () -> Unit,
     onLongPressL2: (HeadingViewItem) -> Unit,
     onOpenCreateL1: () -> Unit,
     onOpenFilePicker: () -> Unit,
@@ -375,6 +378,7 @@ private fun HeadingListScreen(
             onCreateL1 = onOpenCreateL1,
             onCollapseAll = onCollapseAll,
             onExpandAll = onExpandAll,
+            onRefresh = onRefresh,
             performanceMonitor = performanceMonitor,
             showPerfOverlay = showPerfOverlay,
         )
@@ -562,6 +566,7 @@ private fun HeadingListTopBar(
     onCreateL1: () -> Unit,
     onCollapseAll: () -> Unit,
     onExpandAll: () -> Unit,
+    onRefresh: () -> Unit,
     performanceMonitor: PerformanceMonitor,
     showPerfOverlay: Boolean,
 ) {
@@ -592,6 +597,12 @@ private fun HeadingListTopBar(
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    IconButton(onClick = onRefresh) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = stringResource(R.string.refresh),
+                        )
+                    }
                     BulkHeadingActionButton(
                         label = stringResource(R.string.expand_all_label),
                         contentDescription = stringResource(R.string.expand_all_headings),

--- a/app/src/main/java/com/example/orgclock/ui/state/OrgClockUiAction.kt
+++ b/app/src/main/java/com/example/orgclock/ui/state/OrgClockUiAction.kt
@@ -13,6 +13,7 @@ sealed interface OrgClockUiAction {
     data class ToggleL1(val title: String) : OrgClockUiAction
     data object CollapseAll : OrgClockUiAction
     data object ExpandAll : OrgClockUiAction
+    data object RefreshHeadings : OrgClockUiAction
     data class OpenHistory(val item: HeadingViewItem) : OrgClockUiAction
     data object DismissHistory : OrgClockUiAction
     data class StartClock(val item: HeadingViewItem) : OrgClockUiAction

--- a/app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt
+++ b/app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt
@@ -128,6 +128,14 @@ class OrgClockViewModel(
                 true
             }
 
+            OrgClockUiAction.RefreshHeadings -> {
+                val file = uiState.value.selectedFile
+                if (file != null) {
+                    viewModelScope.launch { loadHeadingsFor(file, updateStatus = false) }
+                }
+                true
+            }
+
             OrgClockUiAction.OpenFilePicker -> {
                 _uiState.update { it.copy(screen = Screen.FilePicker) }
                 true
@@ -573,7 +581,6 @@ class OrgClockViewModel(
             updatePendingClock(lineIndex, false)
             _uiState.update { it.copy(status = status) }
             refreshFilesWithOpenClock()
-            requestHeadingsSync(file)
         } else {
             updateHeadingOpenClock(lineIndex, item.openClock)
             updatePendingClock(lineIndex, false)
@@ -598,7 +605,6 @@ class OrgClockViewModel(
             updatePendingClock(lineIndex, false)
             _uiState.update { it.copy(status = status) }
             refreshFilesWithOpenClock()
-            requestHeadingsSync(file)
         } else {
             updateHeadingOpenClock(lineIndex, item.openClock)
             updatePendingClock(lineIndex, false)
@@ -623,7 +629,6 @@ class OrgClockViewModel(
             updatePendingClock(lineIndex, false)
             _uiState.update { it.copy(status = status) }
             refreshFilesWithOpenClock()
-            requestHeadingsSync(file)
         } else {
             updateHeadingOpenClock(lineIndex, item.openClock)
             updatePendingClock(lineIndex, false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="collapse_all_headings">Collapse all headings</string>
     <string name="expand_all_label">+++</string>
     <string name="collapse_all_label">---</string>
+    <string name="refresh">Refresh</string>
     <string name="running_count">記録中 %1$d件</string>
     <string name="started_elapsed">%1$s 開始 / %2$d分経過</string>
     <string name="current_root">Current root</string>


### PR DESCRIPTION
- Remove automatic headings sync after clock start/stop/cancel operations to eliminate race condition that caused stale clock records
- Add manual refresh button in top bar for loading external file changes
- Keep refreshFilesWithOpenClock() call to update notification state