### PR TITLE
feat: bootstrap KMP shared module with Android and iOS targets

### DIFF
--- a/.github/workflows/verify-kmp-ios.yml
+++ b/.github/workflows/verify-kmp-ios.yml
@@ -1,0 +1,42 @@
+name: Verify KMP iOS Targets
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-ios-targets:
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Compile iosArm64
+        run: |
+          set -euo pipefail
+          chmod +x ./gradlew
+          ./gradlew --stacktrace :shared:compileKotlinIosArm64
+
+      - name: Compile iosSimulatorArm64
+        run: |
+          set -euo pipefail
+          chmod +x ./gradlew
+          ./gradlew --stacktrace :shared:compileKotlinIosSimulatorArm64

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ Android 端末上で org ファイルの見出しに対して clock 記録を行
 
 `installDebug` の詳細は `docs/install-debug-guide.md` を参照してください。
 
+## Kotlin Multiplatform Bootstrap
+
+- 共有モジュール `:shared` を追加しています（`commonMain` / `androidMain` / `iosMain`）。
+- Linux 環境では iOS アプリの実行・署名はできません。iOS ターゲットのコンパイル検証は macOS CI (`.github/workflows/verify-kmp-ios.yml`) で実行します。
+
+ローカルでの確認例:
+
+```bash
+./gradlew :shared:tasks
+./gradlew :shared:compileDebugKotlinAndroid
+./gradlew :app:assembleDebug
+```
+
 ## CI Distribution (No ADB / No USB)
 
 `adb` や USB 転送を使わずに端末へ更新を反映する場合は、GitHub Actions から Firebase App Distribution へ配布します。

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,7 @@ android {
 dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2025.01.00")
 
+    implementation(project(":shared"))
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("com.android.application") version "8.7.3" apply false
     id("com.android.test") version "8.7.3" apply false
+    id("com.android.library") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.multiplatform") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
+kotlin.native.ignoreDisabledTargets=true
+kotlin.mpp.applyDefaultHierarchyTemplate=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,4 @@ dependencyResolutionManagement {
 rootProject.name = "org-clock-android"
 include(":app")
 include(":benchmark")
+include(":shared")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,58 @@
+@file:OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("com.android.library")
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+        val androidMain by getting
+        val androidUnitTest by getting
+        val iosArm64Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
+
+        val iosArm64Test by getting
+        val iosSimulatorArm64Test by getting
+        val iosTest by creating {
+            dependsOn(commonTest)
+            iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
+        }
+    }
+}
+
+android {
+    namespace = "com.example.orgclock.shared"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 28
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/shared/src/androidMain/AndroidManifest.xml
+++ b/shared/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/shared/src/androidMain/kotlin/com/example/orgclock/shared/PlatformInfo.android.kt
+++ b/shared/src/androidMain/kotlin/com/example/orgclock/shared/PlatformInfo.android.kt
@@ -1,0 +1,3 @@
+package com.example.orgclock.shared
+
+actual fun platformName(): String = "Android"

--- a/shared/src/commonMain/kotlin/com/example/orgclock/shared/PlatformInfo.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/shared/PlatformInfo.kt
@@ -1,0 +1,5 @@
+package com.example.orgclock.shared
+
+expect fun platformName(): String
+
+fun sharedBootstrapMessage(): String = "OrgClock shared bootstrap on ${platformName()}"

--- a/shared/src/iosMain/kotlin/com/example/orgclock/shared/PlatformInfo.ios.kt
+++ b/shared/src/iosMain/kotlin/com/example/orgclock/shared/PlatformInfo.ios.kt
@@ -1,0 +1,3 @@
+package com.example.orgclock.shared
+
+actual fun platformName(): String = "iOS"


### PR DESCRIPTION
  ## Summary
  - Bootstrap Kotlin Multiplatform (KMP) foundation for iOS work.
  - Add new `:shared` module with `commonMain`, `androidMain`, and `iosMain`.
  - Keep Android app behavior unchanged while wiring `:app` to depend on `:shared`.
  - Add macOS CI workflow to compile iOS KMP targets.

  ## Main Changes
  - Root Gradle plugin setup
  - `build.gradle.kts`
    - add `com.android.library` plugin (apply false)
    - add `org.jetbrains.kotlin.multiplatform` plugin (apply false)

  - Project modules
  - `settings.gradle.kts`
    - add `include(":shared")`

  - Shared module
  - `shared/build.gradle.kts`
    - add KMP + Android library config
    - targets: `androidTarget`, `iosArm64`, `iosSimulatorArm64`
    - source set wiring for `commonMain/androidMain/iosMain`
    - JVM target compatibility aligned to Java 17

  - Shared bootstrap sources
  - `shared/src/commonMain/kotlin/com/example/orgclock/shared/PlatformInfo.kt`
  - `shared/src/androidMain/kotlin/com/example/orgclock/shared/PlatformInfo.android.kt`
  - `shared/src/iosMain/kotlin/com/example/orgclock/shared/PlatformInfo.ios.kt`
  - `shared/src/androidMain/AndroidManifest.xml`

  - Android app wiring
  - `app/build.gradle.kts`
    - add `implementation(project(":shared"))`

  - CI
  - `.github/workflows/verify-kmp-ios.yml`
    - macOS job
    - run `:shared:compileKotlinIosArm64`
    - run `:shared:compileKotlinIosSimulatorArm64`

  - Docs / build config
  - `README.md` KMP bootstrap section
  - `gradle.properties` warning controls for current Linux/no-Mac flow

  ## Verification
  - `./gradlew :shared:compileDebugKotlinAndroid :shared:compileReleaseKotlinAndroid :app:assembleDebug` ✅
  - Build completed successfully after JVM target/toolchain fixes.

  ## Notes
  - This PR is bootstrap-only: no functional feature changes.
  - iOS app host/UI is not included yet.
  - Next step is moving pure shared logic (`model/parser/domain`) from `app` into `:shared`.