### PR TITLE
feat: add refresh button to files page

### DIFF
--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -149,6 +150,7 @@ fun OrgClockScreen(
                 onPickRoot = onPickRoot,
                 onSelectFile = { onAction(OrgClockUiAction.SelectFile(it)) },
                 onOpenSettings = { onAction(OrgClockUiAction.OpenSettings) },
+                onRefreshFiles = { onAction(OrgClockUiAction.RefreshFiles) },
             )
 
             Screen.HeadingList -> HeadingListScreen(
@@ -272,6 +274,7 @@ private fun FilePickerScreen(
     onPickRoot: () -> Unit,
     onSelectFile: (OrgFileEntry) -> Unit,
     onOpenSettings: () -> Unit,
+    onRefreshFiles: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -279,9 +282,20 @@ private fun FilePickerScreen(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Button(onClick = onPickRoot) { Text(stringResource(R.string.change_root)) }
             Button(onClick = onOpenSettings) { Text(stringResource(R.string.settings)) }
+            Spacer(modifier = Modifier.weight(1f))
+            IconButton(onClick = onRefreshFiles) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = stringResource(R.string.refresh),
+                )
+            }
         }
         StatusBanner(status)
         Text(stringResource(R.string.select_org_file), style = MaterialTheme.typography.titleMedium)

--- a/app/src/main/java/com/example/orgclock/ui/state/OrgClockUiAction.kt
+++ b/app/src/main/java/com/example/orgclock/ui/state/OrgClockUiAction.kt
@@ -14,6 +14,7 @@ sealed interface OrgClockUiAction {
     data object CollapseAll : OrgClockUiAction
     data object ExpandAll : OrgClockUiAction
     data object RefreshHeadings : OrgClockUiAction
+    data object RefreshFiles : OrgClockUiAction
     data class OpenHistory(val item: HeadingViewItem) : OrgClockUiAction
     data object DismissHistory : OrgClockUiAction
     data class StartClock(val item: HeadingViewItem) : OrgClockUiAction

--- a/app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt
+++ b/app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt
@@ -136,6 +136,11 @@ class OrgClockViewModel(
                 true
             }
 
+            OrgClockUiAction.RefreshFiles -> {
+                viewModelScope.launch { refreshFilesAndRoute() }
+                true
+            }
+
             OrgClockUiAction.OpenFilePicker -> {
                 _uiState.update { it.copy(screen = Screen.FilePicker) }
                 true


### PR DESCRIPTION
 ## Summary

  Add a refresh button to the File Picker page so users can manually reload the org file list without leaving the screen.

  ## Why

  When files are added/updated outside the app, the File Picker list can become stale. This change provides an explicit user
  action to refresh file state on demand.

  ## Changes

  - UI: Added a refresh icon button to FilePickerScreen top row.
  - Routing: Wired file picker refresh click to a new UI action.
  - State/Actions: Added OrgClockUiAction.RefreshFiles.
  ## Public API / Interface Changes
  - Added new UI action type:
      - OrgClockUiAction.RefreshFiles
  - Updated composable contract:
      - FilePickerScreen(..., onRefreshFiles: () -> Unit)

  ## Files Changed

  - app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
  - app/src/main/java/com/example/orgclock/ui/state/OrgClockUiAction.kt
  - app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt

  ## Testing

  - Manual:
      1. Open File Picker screen.
      2. Verify refresh icon is visible in the top-right area.
      3. Tap refresh and confirm file list/status updates without navigation.
  - Regression:
      1. Verify existing actions (Change root, Settings, file selection) still work.
      2. Verify no impact to Heading List refresh behavior.

  ## Notes

  - This PR description is intentionally scoped to the refresh feature only (commit ed8ef0a).
  - Current branch feat/add-refresh-button-to-files-page also contains aa40462 (fix: properly dismiss notifications when clocks
    are stopped) relative to main.

  ## Assumptions / Defaults

  - Base branch is main.
  - You will open a refresh-only PR after splitting/rebasing the branch to exclude aa40462.