### PR TITLE
fix(notification): separate foreground and clock notification ID ranges

### DIFF
--- a/app/src/main/java/com/example/orgclock/notification/ClockInNotificationService.kt
+++ b/app/src/main/java/com/example/orgclock/notification/ClockInNotificationService.kt
@@ -181,8 +181,8 @@ class ClockInNotificationService : Service() {
                 title = getString(R.string.notif_title_clock_in),
                 summary = getString(R.string.notif_summary_no_active),
             )
-            manager.notify(NOTIFICATION_ID_BASE, notification)
-            currentIds.add(NOTIFICATION_ID_BASE)
+            manager.notify(CLOCK_NOTIFICATION_BASE, notification)
+            currentIds.add(CLOCK_NOTIFICATION_BASE)
         } else {
             entries.forEach { entry ->
                 val notificationId = getNotificationId(entry.fileId, entry.headingLineIndex)
@@ -192,7 +192,7 @@ class ClockInNotificationService : Service() {
             }
         }
         
-        for (i in NOTIFICATION_ID_BASE until NOTIFICATION_ID_BASE + 100) {
+        for (i in CLOCK_NOTIFICATION_BASE until CLOCK_NOTIFICATION_BASE + CLOCK_NOTIFICATION_RANGE) {
             if (i !in currentIds) {
                 manager.cancel(i)
             }
@@ -200,7 +200,7 @@ class ClockInNotificationService : Service() {
     }
 
     private fun getNotificationId(fileId: String, lineIndex: Int): Int {
-        return NOTIFICATION_ID_BASE + Math.abs((fileId.hashCode() + lineIndex) % 100)
+        return CLOCK_NOTIFICATION_BASE + Math.abs((fileId.hashCode() + lineIndex) % CLOCK_NOTIFICATION_RANGE)
     }
 
     private fun buildIndividualClockNotification(entry: ClockInEntry): Notification {
@@ -249,18 +249,18 @@ class ClockInNotificationService : Service() {
 
     private fun notifyForeground(notification: Notification) {
         val manager = getSystemService(NotificationManager::class.java)
-        manager.notify(NOTIFICATION_ID, notification)
+        manager.notify(FOREGROUND_NOTIFICATION_ID, notification)
     }
 
     private fun startForegroundCompat(notification: Notification) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(
-                NOTIFICATION_ID,
+                FOREGROUND_NOTIFICATION_ID,
                 notification,
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
             )
         } else {
-            startForeground(NOTIFICATION_ID, notification)
+            startForeground(FOREGROUND_NOTIFICATION_ID, notification)
         }
     }
 
@@ -334,8 +334,9 @@ class ClockInNotificationService : Service() {
     companion object {
         private const val TAG = "ClockInNotificationSvc"
         private const val CHANNEL_ID = "clock_in_ongoing"
-        private const val NOTIFICATION_ID = 1001
-        private const val NOTIFICATION_ID_BASE = 1000
+        private const val FOREGROUND_NOTIFICATION_ID = 1
+        private const val CLOCK_NOTIFICATION_BASE = 2000
+        private const val CLOCK_NOTIFICATION_RANGE = 100
 
         private const val ACTION_SYNC = "com.example.orgclock.notification.SYNC"
         private const val ACTION_STOP = "com.example.orgclock.notification.STOP"


### PR DESCRIPTION
## Summary

  ClockInNotificationService の通知ID設計を見直し、foreground通知と個別通知が同じIDレンジを共有しないように分離します。
  これにより、通知更新・取消時の混線リスクを低減します。

  ## Background / Problem

  これまで foreground 通知IDと個別通知IDが近接しており、個別通知の更新・キャンセル処理と foreground 通知の干渉余地がありました。
  本PRでは、IDレンジを明示的に分離して責務を分かりやすくします。

  ## Changes

  - ClockInNotificationService の通知ID定数を分離
      - FOREGROUND_NOTIFICATION_ID = 1
      - CLOCK_NOTIFICATION_BASE = 2000
      - CLOCK_NOTIFICATION_RANGE = 100
  - foreground 通知の更新/開始で FOREGROUND_NOTIFICATION_ID を使用
      - notifyForeground(...)
      - startForegroundCompat(...)
      - 各 clock 通知ID計算

  ## Important Public APIs / Interfaces / Types

  - なし（内部実装のみ）
  - 変更ファイル:
      - app/src/main/java/com/example/orgclock/notification/ClockInNotificationService.kt

  ## Expected Behavior After Change

  - foreground 通知は専用IDで管理され、個別通知の更新・取消で誤って影響を受けない
  - 個別通知は 2000..2099 の範囲で管理される
  - 通知文言や表示ポリシー自体は変更しない（ID設計のみ変更）

  ## Test Cases and Scenarios

  1. 通知有効・同期開始時に foreground 通知が表示される
  2. 稼働あり時に個別通知が表示される
  3. 稼働なし（Alwaysモード）時に「稼働中の見出しはありません」が表示される
  4. 個別通知の更新/キャンセル後も foreground 通知が意図せず消えない
  5. エラー通知更新（root未設定/open失敗/refresh失敗）が foreground 側で継続して動作する

  ## Verification Notes

  - コード上の旧定数参照は置換済み
  - ローカルで ClockInNotificationServiceDecisionTest 実行を試行したが、環境依存の Gradle エラー（wildcard IP 判定）で完了できず

  ## Assumptions and Defaults

  - foreground と個別通知のチャネル分離は本PRのスコープ外
  - 個別通知レンジサイズ 100 は現状要件で十分
  - ベースブランチは main