### PR TITLE
Fix running panel hit handling

### DIFF
--- a/app/src/androidTest/java/com/example/orgclock/ui/app/OrgClockScreenTest.kt
+++ b/app/src/androidTest/java/com/example/orgclock/ui/app/OrgClockScreenTest.kt
@@ -3,23 +3,20 @@ package com.example.orgclock.ui.app
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
 import com.example.orgclock.R
+import com.example.orgclock.data.OrgFileEntry
 import com.example.orgclock.model.HeadingNode
 import com.example.orgclock.model.HeadingPath
 import com.example.orgclock.model.HeadingViewItem
 import com.example.orgclock.model.OpenClockState
-import com.example.orgclock.ui.perf.PerformanceMonitor
-import com.example.orgclock.data.OrgFileEntry
 import com.example.orgclock.notification.NotificationDisplayMode
+import com.example.orgclock.ui.perf.PerformanceMonitor
 import com.example.orgclock.ui.state.OrgClockUiAction
 import com.example.orgclock.ui.state.OrgClockUiState
 import com.example.orgclock.ui.state.Screen
@@ -29,7 +26,6 @@ import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -138,10 +134,62 @@ class OrgClockScreenTest {
     }
 
     @Test
-    fun headingListScreen_lastHeadingStaysAboveTallRunningPanel() {
+    fun headingListScreen_runningPanelShowsAllFourRowsWhenFourClocksAreRunning() {
+        setHeadingListContent(runningClockCount = 4)
+
+        composeRule.onNodeWithTag("running_clocks_panel").assertIsDisplayed()
+        repeat(4) { index ->
+            val taskNumber = index + 1
+            composeRule.onNodeWithTag(runningPanelRowTag("Work/Task $taskNumber")).assertIsDisplayed()
+        }
+        composeRule.onNodeWithTag("running_panel_compact").assertDoesNotExist()
+    }
+
+    @Test
+    fun headingListScreen_runningPanelAutoCollapsesWhenFiveClocksAreRunning() {
+        setHeadingListContent(runningClockCount = 5)
+
+        composeRule.onNodeWithTag("running_clocks_panel").assertIsDisplayed()
+        composeRule.onNodeWithTag("running_panel_toggle").assertIsDisplayed()
+        composeRule.onNodeWithTag("running_panel_compact").assertIsDisplayed()
+        composeRule.onNodeWithTag(runningPanelRowTag("Work/Task 1")).assertDoesNotExist()
+    }
+
+    @Test
+    fun headingListScreen_runningPanelCanExpandAfterAutoCollapse() {
+        setHeadingListContent(runningClockCount = 5)
+
+        composeRule.onNodeWithTag("running_panel_toggle").performClick()
+
+        repeat(5) { index ->
+            val taskNumber = index + 1
+            composeRule.onNodeWithTag(runningPanelRowTag("Work/Task $taskNumber")).assertIsDisplayed()
+        }
+        composeRule.onNodeWithTag("running_panel_compact").assertDoesNotExist()
+    }
+
+    private fun headingItem(
+        level: Int,
+        title: String,
+        path: String,
+        parentL1: String? = null,
+        openClock: OpenClockState? = null,
+    ): HeadingViewItem = HeadingViewItem(
+        node = HeadingNode(
+            lineIndex = 0,
+            level = level,
+            title = title,
+            path = HeadingPath.parse(path),
+            parentL1 = parentL1,
+        ),
+        canStart = level == 2,
+        openClock = openClock,
+    )
+
+    private fun setHeadingListContent(runningClockCount: Int, totalTaskCount: Int = 12) {
         val headings = buildList {
             add(headingItem(level = 1, title = "Work", path = "Work"))
-            repeat(12) { index ->
+            repeat(totalTaskCount) { index ->
                 val taskNumber = index + 1
                 add(
                     headingItem(
@@ -149,7 +197,7 @@ class OrgClockScreenTest {
                         title = "Task $taskNumber",
                         path = "Work/Task $taskNumber",
                         parentL1 = "Work",
-                        openClock = if (index < 4) {
+                        openClock = if (index < runningClockCount) {
                             OpenClockState(Instant.parse("2026-03-08T0${index}:00:00Z"))
                         } else {
                             null
@@ -173,47 +221,8 @@ class OrgClockScreenTest {
                 onAction = {},
             )
         }
-
-        val taskRowTag = headingRowTag("Work/Task 12")
-        composeRule.waitForIdle()
-        composeRule.onNodeWithTag("heading_list")
-            .performScrollToNode(hasTestTag(taskRowTag))
-        composeRule.waitForIdle()
-        composeRule.onNodeWithTag("heading_list")
-            .performScrollToNode(hasTestTag(taskRowTag))
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            val panelBounds = composeRule.onNodeWithTag("running_clocks_panel")
-                .fetchSemanticsNode().boundsInRoot
-            val lastHeadingBounds = composeRule.onNodeWithTag(taskRowTag)
-                .fetchSemanticsNode().boundsInRoot
-            lastHeadingBounds.bottom <= panelBounds.top
-        }
-
-        val panelBounds = composeRule.onNodeWithTag("running_clocks_panel")
-            .fetchSemanticsNode().boundsInRoot
-        val lastHeadingBounds = composeRule.onNodeWithTag(taskRowTag)
-            .fetchSemanticsNode().boundsInRoot
-
-        assertTrue(lastHeadingBounds.bottom <= panelBounds.top)
     }
-
-    private fun headingItem(
-        level: Int,
-        title: String,
-        path: String,
-        parentL1: String? = null,
-        openClock: OpenClockState? = null,
-    ): HeadingViewItem = HeadingViewItem(
-        node = HeadingNode(
-            lineIndex = 0,
-            level = level,
-            title = title,
-            path = HeadingPath.parse(path),
-            parentL1 = parentL1,
-        ),
-        canStart = level == 2,
-        openClock = openClock,
-        )
 }
 
 private fun headingRowTag(path: String): String = "heading_row:$path"
+private fun runningPanelRowTag(path: String): String = "running_panel_row:$path"

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -47,6 +48,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -142,6 +144,10 @@ private val ClockStartTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPat
 private const val HeadingListTag = "heading_list"
 private const val RunningClocksPanelTag = "running_clocks_panel"
 private const val HeadingRowTagPrefix = "heading_row:"
+private const val RunningPanelRowTagPrefix = "running_panel_row:"
+private const val RunningPanelToggleTag = "running_panel_toggle"
+private const val RunningPanelCompactTag = "running_panel_compact"
+private const val RunningPanelCollapseThreshold = 5
 
 @Composable
 fun OrgClockScreen(
@@ -450,7 +456,7 @@ private fun HeadingListScreen(
             onExpandAll = onExpandAll,
             onRefresh = onRefresh,
             performanceMonitor = performanceMonitor,
-                showPerfOverlay = showPerfOverlay,
+            showPerfOverlay = showPerfOverlay,
         )
 
         HeadingListWithRunningPanel(
@@ -666,6 +672,13 @@ private fun RunningClocksPanel(
 ) {
     if (runningItems.isEmpty()) return
 
+    val shouldAutoCollapse = runningItems.size >= RunningPanelCollapseThreshold
+    var expandedByUser by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(shouldAutoCollapse) {
+        if (!shouldAutoCollapse) expandedByUser = false
+    }
+    val isExpanded = !shouldAutoCollapse || expandedByUser
+
     var now by remember { mutableStateOf(nowProvider()) }
     LaunchedEffect(runningItems.isNotEmpty()) {
         if (!runningItems.isNotEmpty()) return@LaunchedEffect
@@ -685,53 +698,85 @@ private fun RunningClocksPanel(
         modifier = modifier,
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text(stringResource(R.string.running_count, runningItems.size), fontWeight = FontWeight.SemiBold)
-            runningItems.forEach { item ->
-                val minutes = maxOf(0L, Duration.between(item.startedAt.toJavaZonedDateTime(now.zone), now).toMinutes())
-                val startedText = remember(item.headingPath, item.startedAt) {
-                    item.startedAt.toJavaZonedDateTime(now.zone).format(ClockStartTimeFormatter)
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(stringResource(R.string.running_count, runningItems.size), fontWeight = FontWeight.SemiBold)
+                if (shouldAutoCollapse) {
+                    TextButton(
+                        onClick = { expandedByUser = !isExpanded },
+                        modifier = Modifier.testTag(RunningPanelToggleTag),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                     ) {
-                        val title = if (item.showL1Hint && !item.l1Title.isNullOrBlank()) {
-                            "${item.l2Title} (${item.l1Title})"
-                        } else {
-                            item.l2Title
-                        }
                         Text(
-                            text = title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Text(
-                            text = stringResource(R.string.started_elapsed, startedText, minutes),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.82f),
+                            text = stringResource(
+                                if (isExpanded) R.string.running_panel_collapse else R.string.running_panel_expand,
+                            ),
+                            color = MaterialTheme.colorScheme.onPrimary,
                         )
                     }
-                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                        ClockActionIconButton(
-                            actionType = ClockActionType.Stop,
-                            onClick = { onStop(item) },
-                            backgroundColor = Color.White.copy(alpha = 0.18f),
-                            enabled = item.headingPath !in pendingClockOps,
-                        )
-                        ClockActionIconButton(
-                            actionType = ClockActionType.Cancel,
-                            onClick = { onCancel(item) },
-                            backgroundColor = Color.White.copy(alpha = 0.18f),
-                            enabled = item.headingPath !in pendingClockOps,
-                        )
+                }
+            }
+
+            if (!isExpanded) {
+                Text(
+                    text = stringResource(R.string.running_panel_expand),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.82f),
+                    modifier = Modifier.testTag(RunningPanelCompactTag),
+                )
+            } else {
+                runningItems.forEach { item ->
+                    val minutes = maxOf(0L, Duration.between(item.startedAt.toJavaZonedDateTime(now.zone), now).toMinutes())
+                    val startedText = remember(item.headingPath, item.startedAt) {
+                        item.startedAt.toJavaZonedDateTime(now.zone).format(ClockStartTimeFormatter)
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(runningPanelRowTag(item.headingPath)),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            val title = if (item.showL1Hint && !item.l1Title.isNullOrBlank()) {
+                                "${item.l2Title} (${item.l1Title})"
+                            } else {
+                                item.l2Title
+                            }
+                            Text(
+                                text = title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                text = stringResource(R.string.started_elapsed, startedText, minutes),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.82f),
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            ClockActionIconButton(
+                                actionType = ClockActionType.Stop,
+                                onClick = { onStop(item) },
+                                backgroundColor = Color.White.copy(alpha = 0.18f),
+                                enabled = item.headingPath !in pendingClockOps,
+                            )
+                            ClockActionIconButton(
+                                actionType = ClockActionType.Cancel,
+                                onClick = { onCancel(item) },
+                                backgroundColor = Color.White.copy(alpha = 0.18f),
+                                enabled = item.headingPath !in pendingClockOps,
+                            )
+                        }
                     }
                 }
             }
@@ -740,6 +785,7 @@ private fun RunningClocksPanel(
 }
 
 private fun headingRowTag(path: HeadingPath): String = "$HeadingRowTagPrefix${path}"
+private fun runningPanelRowTag(path: HeadingPath): String = "$RunningPanelRowTagPrefix${path}"
 
 @Composable
 private fun HeadingListTopBar(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="empty_files_message">orgファイルが見つかりません。ルートを変更するか更新してください。</string>
     <string name="empty_headings_message">見出しがありません。L1を追加するか更新してください。</string>
     <string name="running_count">記録中 %1$d件</string>
+    <string name="running_panel_expand">詳細を表示</string>
+    <string name="running_panel_collapse">折りたたむ</string>
     <string name="started_elapsed">%1$s 開始 / %2$d分経過</string>
     <string name="current_root">Current root</string>
     <string name="none">(none)</string>


### PR DESCRIPTION
## Summary
- make the running clocks panel reserve list space based on its measured height
- keep the running panel on the front hit layer so taps do not fall through to headings behind it
- add Compose UI coverage for stop action dispatch and tall panel spacing

## Testing
- ./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin

## Not Run
- connectedDebugAndroidTest