### PR TITLE
Add desktopApp Compose Desktop scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Android 端末上で org ファイルの見出しに対して clock 記録を行
 
 - 共有モジュール `:shared` を追加しています（`commonMain` / `androidMain` / `iosMain`）。
 - Linux 環境では iOS アプリの実行・署名はできません。iOS ターゲットのコンパイル検証は macOS CI (`.github/workflows/verify-kmp-ios.yml`) で実行します。
+- Desktop MVP の土台として `:desktopApp` を追加しています。ローカル Linux での起動は `./gradlew runDesktop` または `./gradlew :desktopApp:run` を使用します。
 
 ローカルでの確認例:
 
@@ -51,6 +52,7 @@ Android 端末上で org ファイルの見出しに対して clock 記録を行
 ./gradlew :shared:tasks
 ./gradlew :shared:compileDebugKotlinAndroid
 ./gradlew :app:assembleDebug
+./gradlew :desktopApp:run
 ```
 
 ## Local sync-core Integration (Composite Build)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,16 @@ plugins {
     id("com.android.application") version "8.7.3" apply false
     id("com.android.test") version "8.7.3" apply false
     id("com.android.library") version "8.7.3" apply false
+    id("org.jetbrains.compose") version "1.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.0.21" apply false
     id("org.jetbrains.kotlin.multiplatform") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
+}
+
+tasks.register("runDesktop") {
+    group = "application"
+    description = "Runs the Compose Desktop host."
+    dependsOn(":desktopApp:run")
 }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    implementation(compose.desktop.currentOs)
+    implementation(compose.material3)
+}
+
+compose.desktop {
+    application {
+        mainClass = "com.example.orgclock.desktop.MainKt"
+    }
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
@@ -1,0 +1,47 @@
+package com.example.orgclock.desktop
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "Org Clock Desktop",
+    ) {
+        DesktopApp()
+    }
+}
+
+@Composable
+private fun DesktopApp() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = "Org Clock Desktop",
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+                Text(
+                    text = "Desktop MVP host is wired and ready for feature work.",
+                    modifier = Modifier.padding(top = 12.dp),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 
@@ -37,4 +38,5 @@ if (syncCoreDir != null) {
 rootProject.name = "org-clock-android"
 include(":app")
 include(":benchmark")
+include(":desktopApp")
 include(":shared")


### PR DESCRIPTION
## Summary
- add a new :desktopApp module wired into the Gradle build
- add a minimal Compose Desktop entrypoint and root runDesktop task
- document local Linux desktop startup in the README

## Verification
- ./gradlew :desktopApp:build
- ./gradlew :desktopApp:packageUberJarForCurrentOS
- ./gradlew runDesktop --dry-run

Closes #39