### PR TITLE
Implement desktop local-file ClockRepository

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -13,6 +13,11 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
     }
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
     val iosTargets = listOf(
         iosArm64(),
         iosSimulatorArm64(),
@@ -45,6 +50,11 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("junit:junit:4.13.2")
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
         val iosArm64Main by getting

--- a/shared/src/jvmMain/kotlin/com/example/orgclock/data/BackupPolicyConfig.kt
+++ b/shared/src/jvmMain/kotlin/com/example/orgclock/data/BackupPolicyConfig.kt
@@ -1,0 +1,11 @@
+package com.example.orgclock.data
+
+data class BackupPolicyConfig(
+    val backupGenerations: Int = DEFAULT_BACKUP_GENERATIONS,
+    val clockBackupIntervalMs: Long = DEFAULT_CLOCK_BACKUP_INTERVAL_MS,
+) {
+    companion object {
+        const val DEFAULT_BACKUP_GENERATIONS: Int = 20
+        const val DEFAULT_CLOCK_BACKUP_INTERVAL_MS: Long = 15 * 60 * 1000L
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/example/orgclock/data/BackupPolicyDecisions.kt
+++ b/shared/src/jvmMain/kotlin/com/example/orgclock/data/BackupPolicyDecisions.kt
@@ -1,0 +1,18 @@
+package com.example.orgclock.data
+
+internal fun shouldCreateClockBackup(
+    lastClockBackupAtMs: Long?,
+    nowMs: Long,
+    clockBackupIntervalMs: Long,
+): Boolean {
+    if (lastClockBackupAtMs == null) return true
+    return (nowMs - lastClockBackupAtMs) >= clockBackupIntervalMs
+}
+
+internal fun <T> backupsToPrune(
+    backupsSortedDesc: List<T>,
+    backupGenerations: Int,
+): List<T> {
+    val generations = maxOf(0, backupGenerations)
+    return backupsSortedDesc.drop(generations)
+}

--- a/shared/src/jvmMain/kotlin/com/example/orgclock/data/DesktopFileOrgRepository.kt
+++ b/shared/src/jvmMain/kotlin/com/example/orgclock/data/DesktopFileOrgRepository.kt
@@ -1,0 +1,239 @@
+package com.example.orgclock.data
+
+import com.example.orgclock.model.OrgDocument
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.security.MessageDigest
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.io.path.absolute
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.getLastModifiedTime
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class DesktopFileOrgRepository(
+    rootDirectory: Path,
+    private val backupPolicy: BackupPolicyConfig = BackupPolicyConfig(),
+    private val nowMsProvider: () -> Long = System::currentTimeMillis,
+) : ClockRepository {
+    private val rootPath: Path = rootDirectory.absolute().normalize().createDirectories()
+    private val lastClockBackupByFileId = mutableMapOf<String, Long>()
+
+    init {
+        require(rootPath.exists() && rootPath.isDirectory()) { "Root path must be a directory" }
+    }
+
+    override suspend fun listOrgFiles(): Result<List<OrgFileEntry>> = runCatching {
+        rootPath.listDirectoryEntries("*.org")
+            .filter { it.isRegularFile() }
+            .map { path ->
+                OrgFileEntry(
+                    fileId = path.absolutePathString(),
+                    displayName = path.name,
+                    modifiedAt = path.getLastModifiedTime().toMillis().takeIf { it > 0 }?.let(Instant::fromEpochMilliseconds),
+                )
+            }
+            .sortedByDescending { it.modifiedAt?.toEpochMilliseconds() ?: Long.MIN_VALUE }
+    }
+
+    override suspend fun loadFile(fileId: String): Result<OrgDocument> = runCatching {
+        val path = resolveExistingFile(fileId)
+        val rawText = path.readText(StandardCharsets.UTF_8)
+        val lines = parseLines(rawText)
+        OrgDocument(
+            date = parseDateFromFileName(path.name),
+            lines = lines,
+            hash = hash(canonicalText(lines)),
+        )
+    }
+
+    override suspend fun saveFile(
+        fileId: String,
+        lines: List<String>,
+        expectedHash: String,
+        writeIntent: FileWriteIntent,
+    ): SaveResult {
+        val path = runCatching { resolveExistingFile(fileId) }
+            .getOrElse { return SaveResult.ValidationError(it.message ?: "Invalid file") }
+        return saveToPath(
+            path = path,
+            lines = lines,
+            expectedHash = expectedHash,
+            createIfMissing = false,
+            writeIntent = writeIntent,
+        )
+    }
+
+    override suspend fun loadDaily(date: LocalDate): Result<OrgDocument> = runCatching {
+        val path = dailyPath(date)
+        val rawText = if (path.exists()) path.readText(StandardCharsets.UTF_8) else null
+        val lines = rawText?.let(::parseLines).orEmpty()
+        OrgDocument(
+            date = date,
+            lines = lines,
+            hash = hash(canonicalText(lines)),
+        )
+    }
+
+    override suspend fun saveDaily(date: LocalDate, lines: List<String>, expectedHash: String): SaveResult =
+        saveToPath(
+            path = dailyPath(date),
+            lines = lines,
+            expectedHash = expectedHash,
+            createIfMissing = true,
+            writeIntent = FileWriteIntent.UserEdit,
+        )
+
+    private fun saveToPath(
+        path: Path,
+        lines: List<String>,
+        expectedHash: String,
+        createIfMissing: Boolean,
+        writeIntent: FileWriteIntent,
+    ): SaveResult {
+        val normalizedPath = path.toAbsolutePath().normalize()
+        if (!isUnderRoot(normalizedPath)) {
+            return SaveResult.ValidationError("File is outside repository root")
+        }
+        if (!normalizedPath.exists() && !createIfMissing) {
+            return SaveResult.ValidationError("File not found")
+        }
+
+        return runCatching {
+            val existingRawText = if (normalizedPath.exists()) {
+                normalizedPath.readText(StandardCharsets.UTF_8)
+            } else {
+                null
+            }
+            val existingLines = existingRawText?.let(::parseLines).orEmpty()
+            val existingHash = hash(canonicalText(existingLines))
+            if (existingHash != expectedHash) {
+                return SaveResult.Conflict("File changed by another process.")
+            }
+
+            val nowMs = nowMsProvider()
+            val shouldBackup = if (createIfMissing) {
+                true
+            } else {
+                shouldCreateBackup(
+                    fileId = normalizedPath.absolutePathString(),
+                    writeIntent = writeIntent,
+                    nowMs = nowMs,
+                )
+            }
+            if (shouldBackup) {
+                val backupCreated = createBackupIfNeeded(normalizedPath, existingRawText, nowMs)
+                if (backupCreated && writeIntent == FileWriteIntent.ClockMutation) {
+                    synchronized(lastClockBackupByFileId) {
+                        lastClockBackupByFileId[normalizedPath.absolutePathString()] = nowMs
+                    }
+                }
+            }
+
+            val lineSeparator = existingRawText?.let(::detectLineSeparator) ?: "\n"
+            val trailingNewline = existingRawText?.endsWith('\n') ?: false
+            val outputText = formatOutputText(lines, lineSeparator, trailingNewline)
+            Files.writeString(
+                normalizedPath,
+                outputText,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE,
+            )
+            SaveResult.Success
+        }.getOrElse {
+            SaveResult.IoError(it.message ?: "Unknown I/O error")
+        }
+    }
+
+    private fun shouldCreateBackup(fileId: String, writeIntent: FileWriteIntent, nowMs: Long): Boolean {
+        if (writeIntent == FileWriteIntent.UserEdit) return true
+        val lastClockBackupAt = synchronized(lastClockBackupByFileId) {
+            lastClockBackupByFileId[fileId]
+        }
+        return shouldCreateClockBackup(
+            lastClockBackupAtMs = lastClockBackupAt,
+            nowMs = nowMs,
+            clockBackupIntervalMs = backupPolicy.clockBackupIntervalMs,
+        )
+    }
+
+    private fun createBackupIfNeeded(path: Path, existingRawText: String?, nowMs: Long): Boolean {
+        if (existingRawText.isNullOrEmpty()) return false
+
+        val backupName = ".${path.name}.bak.${backupStamp(nowMs)}"
+        val backupPath = path.parent.resolve(backupName)
+        backupPath.writeText(existingRawText, StandardCharsets.UTF_8)
+
+        val backups = path.parent.listDirectoryEntries(".${path.name}.bak.*")
+            .filter { it.isRegularFile() }
+            .sortedByDescending { it.name }
+
+        backupsToPrune(backups, backupPolicy.backupGenerations).forEach { Files.deleteIfExists(it) }
+        return true
+    }
+
+    private fun resolveExistingFile(fileId: String): Path {
+        val path = runCatching { Path.of(fileId).toAbsolutePath().normalize() }
+            .getOrElse { throw IllegalArgumentException("Invalid file id") }
+        require(isUnderRoot(path)) { "File is outside repository root" }
+        require(path.exists() && path.isRegularFile()) { "File not found" }
+        return path
+    }
+
+    private fun isUnderRoot(path: Path): Boolean = path.startsWith(rootPath)
+
+    private fun dailyPath(date: LocalDate): Path = rootPath.resolve("$date.org")
+
+    private fun parseLines(rawText: String): List<String> {
+        if (rawText.isEmpty()) return emptyList()
+        return rawText.split('\n')
+            .map { it.removeSuffix("\r") }
+            .let { lines -> if (lines.isNotEmpty() && lines.last().isEmpty()) lines.dropLast(1) else lines }
+    }
+
+    private fun canonicalText(lines: List<String>): String = lines.joinToString("\n")
+
+    private fun detectLineSeparator(rawText: String): String = if (rawText.contains("\r\n")) "\r\n" else "\n"
+
+    private fun formatOutputText(lines: List<String>, lineSeparator: String, trailingNewline: Boolean): String {
+        val body = lines.joinToString(lineSeparator)
+        if (body.isEmpty()) return body
+        return if (trailingNewline) body + lineSeparator else body
+    }
+
+    private fun parseDateFromFileName(name: String): LocalDate =
+        runCatching { LocalDate.parse(name.removeSuffix(".org")) }
+            .getOrElse { today() }
+
+    private fun hash(text: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(text.toByteArray(StandardCharsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun backupStamp(nowMs: Long): String =
+        java.time.Instant.ofEpochMilli(nowMs)
+            .atZone(ZoneId.systemDefault())
+            .format(BACKUP_STAMP_FORMAT)
+
+    private fun today(): LocalDate {
+        val current = java.time.LocalDate.now(ZoneId.systemDefault())
+        return LocalDate(current.year, current.monthValue, current.dayOfMonth)
+    }
+
+    private companion object {
+        val BACKUP_STAMP_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/example/orgclock/shared/IosCoreFlowFacade.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/example/orgclock/shared/IosCoreFlowFacade.jvm.kt
@@ -1,0 +1,9 @@
+package com.example.orgclock.shared
+
+actual class IosCoreFlowFacade actual constructor() {
+    actual fun listFilesSummary(): String = "listFiles=unsupported-on-jvm"
+
+    actual fun verifyDailyReadWriteRoundTrip(): String = "daily=unsupported-on-jvm"
+
+    actual fun listHeadingsSummaryForFirstFile(): String = "headings=unsupported-on-jvm"
+}

--- a/shared/src/jvmMain/kotlin/com/example/orgclock/shared/PlatformInfo.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/example/orgclock/shared/PlatformInfo.jvm.kt
@@ -1,0 +1,3 @@
+package com.example.orgclock.shared
+
+actual fun platformName(): String = "JVM"

--- a/shared/src/jvmTest/kotlin/com/example/orgclock/data/DesktopFileOrgRepositoryTest.kt
+++ b/shared/src/jvmTest/kotlin/com/example/orgclock/data/DesktopFileOrgRepositoryTest.kt
@@ -1,0 +1,241 @@
+package com.example.orgclock.data
+
+import com.example.orgclock.domain.ClockService
+import com.example.orgclock.model.HeadingPath
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DesktopFileOrgRepositoryTest {
+    private val tempRoots = mutableListOf<Path>()
+
+    @AfterTest
+    fun cleanup() {
+        tempRoots.asReversed().forEach { root ->
+            Files.walk(root).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+            }
+        }
+        tempRoots.clear()
+    }
+
+    @Test
+    fun listOrgFiles_returnsAbsolutePathIdsSortedByModifiedTime() {
+        val root = tempRoot()
+        val older = write(root.resolve("2026-03-01.org"), "* Older")
+        val newer = write(root.resolve("notes.org"), "* Newer")
+        Files.setLastModifiedTime(older, java.nio.file.attribute.FileTime.fromMillis(1_000))
+        Files.setLastModifiedTime(newer, java.nio.file.attribute.FileTime.fromMillis(2_000))
+        val repository = DesktopFileOrgRepository(root)
+
+        val files = runSuspend { repository.listOrgFiles() }.getOrThrow()
+
+        assertEquals(listOf(newer.absolutePathString(), older.absolutePathString()), files.map { it.fileId })
+        assertEquals(listOf("notes.org", "2026-03-01.org"), files.map { it.displayName })
+    }
+
+    @Test
+    fun saveFile_preservesExistingLineEndingsAndTrailingNewline() {
+        val root = tempRoot()
+        val path = write(root.resolve("2026-03-01.org"), "* M4\r\n** Task\r\n")
+        val repository = DesktopFileOrgRepository(root)
+        val before = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+
+        val save = runSuspend {
+            repository.saveFile(
+                fileId = path.absolutePathString(),
+                lines = listOf("* M4", "** Task", "CLOCK: [2026-03-01 Sat 09:00]--[2026-03-01 Sat 10:00]"),
+                expectedHash = before.hash,
+                writeIntent = FileWriteIntent.UserEdit,
+            )
+        }
+
+        assertEquals(SaveResult.Success, save)
+        assertEquals(
+            "* M4\r\n** Task\r\nCLOCK: [2026-03-01 Sat 09:00]--[2026-03-01 Sat 10:00]\r\n",
+            path.readText(StandardCharsets.UTF_8),
+        )
+    }
+
+    @Test
+    fun saveFile_withStaleHash_returnsConflict() {
+        val root = tempRoot()
+        val path = write(root.resolve("2026-03-01.org"), "* M4\n")
+        val repository = DesktopFileOrgRepository(root)
+        val before = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+
+        write(path, "* M4\n** Changed elsewhere\n")
+
+        val save = runSuspend {
+            repository.saveFile(
+                fileId = path.absolutePathString(),
+                lines = listOf("* M4", "** Local edit"),
+                expectedHash = before.hash,
+                writeIntent = FileWriteIntent.UserEdit,
+            )
+        }
+
+        assertIs<SaveResult.Conflict>(save)
+    }
+
+    @Test
+    fun saveFile_createsAndPrunesBackups() {
+        val root = tempRoot()
+        val path = write(root.resolve("2026-03-01.org"), "* M4\n")
+        var nowMs = 1_000L
+        val repository = DesktopFileOrgRepository(
+            rootDirectory = root,
+            backupPolicy = BackupPolicyConfig(backupGenerations = 2, clockBackupIntervalMs = 10_000L),
+            nowMsProvider = { nowMs },
+        )
+
+        var current = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+        assertEquals(
+            SaveResult.Success,
+            runSuspend {
+                repository.saveFile(path.absolutePathString(), listOf("* M4", "** One"), current.hash, FileWriteIntent.UserEdit)
+            },
+        )
+
+        nowMs = 2_000L
+        current = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+        assertEquals(
+            SaveResult.Success,
+            runSuspend {
+                repository.saveFile(path.absolutePathString(), listOf("* M4", "** Two"), current.hash, FileWriteIntent.UserEdit)
+            },
+        )
+
+        nowMs = 3_000L
+        current = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+        assertEquals(
+            SaveResult.Success,
+            runSuspend {
+                repository.saveFile(path.absolutePathString(), listOf("* M4", "** Three"), current.hash, FileWriteIntent.UserEdit)
+            },
+        )
+
+        val backups = root.listDirectoryEntries(".2026-03-01.org.bak.*").sortedBy { it.name }
+        assertEquals(2, backups.size)
+        assertEquals(
+            listOf(
+                ".2026-03-01.org.bak.${backupStamp(2_000L)}",
+                ".2026-03-01.org.bak.${backupStamp(3_000L)}",
+            ),
+            backups.map { it.name },
+        )
+        assertEquals("* M4\n** One\n", backups[0].readText(StandardCharsets.UTF_8))
+        assertEquals("* M4\n** Two\n", backups[1].readText(StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun saveFile_clockMutationRateLimitsBackups() {
+        val root = tempRoot()
+        val path = write(root.resolve("2026-03-01.org"), "* M4\n")
+        var nowMs = 1_000L
+        val repository = DesktopFileOrgRepository(
+            rootDirectory = root,
+            backupPolicy = BackupPolicyConfig(backupGenerations = 10, clockBackupIntervalMs = 1_000L),
+            nowMsProvider = { nowMs },
+        )
+
+        var current = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+        assertEquals(
+            SaveResult.Success,
+            runSuspend {
+                repository.saveFile(path.absolutePathString(), listOf("* M4", "** One"), current.hash, FileWriteIntent.ClockMutation)
+            },
+        )
+
+        nowMs = 1_500L
+        current = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+        assertEquals(
+            SaveResult.Success,
+            runSuspend {
+                repository.saveFile(path.absolutePathString(), listOf("* M4", "** Two"), current.hash, FileWriteIntent.ClockMutation)
+            },
+        )
+
+        nowMs = 2_500L
+        current = runSuspend { repository.loadFile(path.absolutePathString()) }.getOrThrow()
+        assertEquals(
+            SaveResult.Success,
+            runSuspend {
+                repository.saveFile(path.absolutePathString(), listOf("* M4", "** Three"), current.hash, FileWriteIntent.ClockMutation)
+            },
+        )
+
+        val backups = root.listDirectoryEntries(".2026-03-01.org.bak.*")
+        assertEquals(2, backups.size)
+    }
+
+    @Test
+    fun clockService_runsAgainstDesktopRepository() {
+        val root = tempRoot()
+        val repository = DesktopFileOrgRepository(root)
+        val service = ClockService(repository)
+        val date = LocalDate(2026, 3, 10)
+        val initial = listOf("* M4", "** Task")
+
+        val before = runSuspend { repository.loadDaily(date) }.getOrThrow()
+        assertEquals(SaveResult.Success, runSuspend { repository.saveDaily(date, initial, before.hash) })
+
+        val result = runSuspend {
+            service.startClock(
+                dateTime = Instant.parse("2026-03-10T09:00:00Z"),
+                headingPath = HeadingPath(listOf("M4", "Task")),
+                timeZone = TimeZone.UTC,
+            )
+        }
+
+        assertTrue(result.isSuccess)
+        val updated = runSuspend { repository.loadDaily(date) }.getOrThrow()
+        val clockLine = updated.lines.firstOrNull { it.contains("CLOCK:") }
+        assertTrue(clockLine != null)
+        assertTrue(clockLine.contains("2026-03-10"))
+        assertTrue(clockLine.contains("09:00"))
+    }
+
+    private fun tempRoot(): Path = createTempDirectory("desktop-repo-test").also(tempRoots::add)
+
+    private fun write(path: Path, text: String): Path {
+        Files.writeString(path, text, StandardCharsets.UTF_8)
+        return path
+    }
+
+    private fun backupStamp(nowMs: Long): String =
+        java.time.Instant.ofEpochMilli(nowMs)
+            .atZone(ZoneId.systemDefault())
+            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
+
+    private fun <T> runSuspend(block: suspend () -> T): T {
+        var completion: Result<T>? = null
+        block.startCoroutine(
+            object : Continuation<T> {
+                override val context = EmptyCoroutineContext
+                override fun resumeWith(result: Result<T>) {
+                    completion = result
+                }
+            },
+        )
+        return completion?.getOrThrow() ?: error("Suspend function did not complete synchronously")
+    }
+}


### PR DESCRIPTION
## Summary
- add a JVM desktop  backed by the local filesystem
- preserve conflict detection, line-ending behavior, and backup pruning semantics
- add focused JVM tests covering repository behavior and  integration

## Testing
- ./gradlew :shared:jvmTest