### PR TITLE
Add desktop settings persistence and composition root

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     implementation(compose.desktop.currentOs)
     implementation(compose.material3)
     implementation(project(":shared"))
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 }
 
 compose.desktop {

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
@@ -1,0 +1,226 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.data.ClockRepository
+import com.example.orgclock.data.DesktopFileOrgRepository
+import com.example.orgclock.domain.ClockMutationResult
+import com.example.orgclock.domain.ClockService
+import com.example.orgclock.domain.FileOperationCoordinator
+import com.example.orgclock.domain.InMemoryFileOperationCoordinator
+import com.example.orgclock.model.ClosedClockEntry
+import com.example.orgclock.model.HeadingPath
+import com.example.orgclock.model.HeadingViewItem
+import com.example.orgclock.presentation.OrgClockPresentationState
+import com.example.orgclock.presentation.RootReference
+import com.example.orgclock.presentation.Screen
+import com.example.orgclock.presentation.StatusMessageKey
+import com.example.orgclock.presentation.StatusText
+import com.example.orgclock.presentation.StatusTone
+import com.example.orgclock.presentation.UiStatus
+import com.example.orgclock.time.ClockEnvironment
+import com.example.orgclock.time.today
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaZoneId
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+
+data class DesktopMvpDependencies(
+    val loadSavedRootReference: () -> RootReference?,
+    val saveRootReference: (RootReference) -> Unit,
+    val openRoot: suspend (RootReference) -> Result<Unit>,
+    val listFiles: suspend () -> Result<List<com.example.orgclock.data.OrgFileEntry>>,
+    val listFilesWithOpenClock: suspend () -> Result<Set<String>>,
+    val listHeadings: suspend (String) -> Result<List<HeadingViewItem>>,
+    val startClock: suspend (String, HeadingPath) -> Result<ClockMutationResult>,
+    val stopClock: suspend (String, HeadingPath) -> Result<ClockMutationResult>,
+    val cancelClock: suspend (String, HeadingPath) -> Result<ClockMutationResult>,
+    val listClosedClocks: suspend (String, HeadingPath) -> Result<List<ClosedClockEntry>>,
+    val editClosedClock: suspend (String, HeadingPath, Int, java.time.ZonedDateTime, java.time.ZonedDateTime) -> Result<Unit>,
+    val deleteClosedClock: suspend (String, HeadingPath, Int) -> Result<Unit>,
+    val createL1Heading: suspend (String, String, Boolean) -> Result<Unit>,
+    val createL2Heading: suspend (String, HeadingPath, String, Boolean) -> Result<Unit>,
+    val nowProvider: () -> java.time.ZonedDateTime,
+    val todayProvider: () -> java.time.LocalDate,
+    val zoneIdProvider: () -> java.time.ZoneId,
+)
+
+data class DesktopHostSnapshot(
+    val presentationState: OrgClockPresentationState,
+    val files: List<com.example.orgclock.data.OrgFileEntry> = emptyList(),
+    val filesWithOpenClock: Set<String> = emptySet(),
+    val openClockCount: Int = 0,
+    val fileFailureCount: Int = 0,
+)
+
+class DesktopAppGraph(
+    private val settingsStore: DesktopSettingsStore = DesktopSettingsStore(),
+    private val clockEnvironment: ClockEnvironment = DesktopSystemClockEnvironment,
+    private val repositoryFactory: (Path) -> ClockRepository = ::DesktopFileOrgRepository,
+    private val coordinatorFactory: () -> FileOperationCoordinator = ::InMemoryFileOperationCoordinator,
+) {
+    private var currentRootReference: RootReference? = null
+    private var repository: ClockRepository? = null
+    private var clockService: ClockService? = null
+    private var openClockScanner: DesktopOpenClockScanner? = null
+    private var status: UiStatus = defaultStatus()
+
+    init {
+        restoreSavedRoot()
+    }
+
+    fun dependencies(): DesktopMvpDependencies {
+        return DesktopMvpDependencies(
+            loadSavedRootReference = { settingsStore.load().lastRootReference },
+            saveRootReference = { settingsStore.save(DesktopHostSettings(lastRootReference = it)) },
+            openRoot = ::openRoot,
+            listFiles = { repository?.listOrgFiles() ?: Result.failure(missingRootError()) },
+            listFilesWithOpenClock = {
+                openClockScanner
+                    ?.scan(clockEnvironment.currentTimeZone())
+                    ?.map { result -> result.entries.asSequence().map { it.fileId }.toSet() }
+                    ?: Result.failure(missingRootError())
+            },
+            listHeadings = { fileId ->
+                clockService?.listHeadings(fileId, clockEnvironment.currentTimeZone())
+                    ?: Result.failure(missingRootError())
+            },
+            startClock = { fileId, headingPath ->
+                clockService?.startClockInFile(fileId, headingPath, clockEnvironment.now(), clockEnvironment.currentTimeZone())
+                    ?: Result.failure(missingRootError())
+            },
+            stopClock = { fileId, headingPath ->
+                clockService?.stopClockInFile(fileId, headingPath, clockEnvironment.now(), clockEnvironment.currentTimeZone())
+                    ?: Result.failure(missingRootError())
+            },
+            cancelClock = { fileId, headingPath ->
+                clockService?.cancelClockInFile(fileId, headingPath)
+                    ?: Result.failure(missingRootError())
+            },
+            listClosedClocks = { fileId, headingPath ->
+                clockService?.listClosedClocksInFile(fileId, headingPath, clockEnvironment.currentTimeZone())
+                    ?: Result.failure(missingRootError())
+            },
+            editClosedClock = { fileId, headingPath, lineIndex, start, end ->
+                clockService?.editClosedClockInFile(
+                    fileId = fileId,
+                    headingPath = headingPath,
+                    clockLineIndex = lineIndex,
+                    newStart = Instant.fromEpochMilliseconds(start.toInstant().toEpochMilli()),
+                    newEnd = Instant.fromEpochMilliseconds(end.toInstant().toEpochMilli()),
+                    timeZone = clockEnvironment.currentTimeZone(),
+                ) ?: Result.failure(missingRootError())
+            },
+            deleteClosedClock = { fileId, headingPath, lineIndex ->
+                clockService?.deleteClosedClockInFile(fileId, headingPath, lineIndex)
+                    ?: Result.failure(missingRootError())
+            },
+            createL1Heading = { fileId, title, attachTplTag ->
+                clockService?.createL1HeadingInFile(fileId, title, attachTplTag)
+                    ?: Result.failure(missingRootError())
+            },
+            createL2Heading = { fileId, parent, title, attachTplTag ->
+                clockService?.createL2HeadingInFile(fileId, parent, title, attachTplTag)
+                    ?: Result.failure(missingRootError())
+            },
+            nowProvider = { clockEnvironment.now().toJavaInstant().atZone(clockEnvironment.currentTimeZone().toJavaZoneId()) },
+            todayProvider = {
+                val today = clockEnvironment.today()
+                java.time.LocalDate.of(today.year, today.monthNumber, today.dayOfMonth)
+            },
+            zoneIdProvider = { clockEnvironment.currentTimeZone().toJavaZoneId() },
+        )
+    }
+
+    suspend fun openRoot(rootReference: RootReference): Result<Unit> = runCatching {
+        attachRoot(rootReference, persist = true)
+    }
+
+    suspend fun snapshot(): DesktopHostSnapshot {
+        val presentationState = OrgClockPresentationState(
+            screen = if (currentRootReference == null) Screen.RootSetup else Screen.FilePicker,
+            rootReference = currentRootReference,
+            status = status,
+        )
+        val currentRepository = repository ?: return DesktopHostSnapshot(presentationState = presentationState)
+        val files = currentRepository.listOrgFiles().getOrElse {
+            return DesktopHostSnapshot(
+                presentationState = presentationState.copy(
+                    status = failureStatus(StatusMessageKey.FailedListingFiles, it.message ?: "unknown error"),
+                ),
+            )
+        }
+        val scanResult = openClockScanner?.scan(clockEnvironment.currentTimeZone())
+        val openEntries = scanResult?.getOrNull()
+        return DesktopHostSnapshot(
+            presentationState = presentationState,
+            files = files,
+            filesWithOpenClock = openEntries?.entries?.asSequence()?.map { it.fileId }?.toSet().orEmpty(),
+            openClockCount = openEntries?.entries?.size ?: 0,
+            fileFailureCount = openEntries?.failedFiles?.size ?: 0,
+        )
+    }
+
+    private fun restoreSavedRoot() {
+        val savedRoot = settingsStore.load().lastRootReference ?: return
+        runCatching {
+            attachRoot(savedRoot, persist = false)
+        }.onFailure { error ->
+            settingsStore.clear()
+            currentRootReference = null
+            repository = null
+            clockService = null
+            openClockScanner = null
+            status = failureStatus(StatusMessageKey.FailedOpenRoot, error.message ?: "unknown error")
+        }
+    }
+
+    private fun attachRoot(rootReference: RootReference, persist: Boolean) {
+        val normalized = normalizeRoot(rootReference)
+        val repository = repositoryFactory(normalized)
+        val clockService = ClockService(repository, fileOperationCoordinator = coordinatorFactory())
+        currentRootReference = RootReference(normalized.toString())
+        this.repository = repository
+        this.clockService = clockService
+        this.openClockScanner = DesktopOpenClockScanner(repository)
+        status = UiStatus(
+            text = StatusText(StatusMessageKey.RootSet),
+            tone = StatusTone.Success,
+        )
+        if (persist) {
+            settingsStore.save(DesktopHostSettings(lastRootReference = currentRootReference))
+        }
+    }
+
+    private fun normalizeRoot(rootReference: RootReference): Path {
+        val path = Path.of(rootReference.rawValue).absolute().normalize()
+        require(path.exists() && path.isDirectory()) { "Selected root must be an existing directory" }
+        return path
+    }
+
+    private fun missingRootError(): IllegalStateException =
+        IllegalStateException("Desktop root is not opened")
+
+    private fun failureStatus(key: StatusMessageKey, reason: String): UiStatus {
+        return UiStatus(
+            text = StatusText(key, listOf(reason)),
+            tone = StatusTone.Error,
+        )
+    }
+
+    private fun defaultStatus(): UiStatus {
+        return UiStatus(
+            text = StatusText(StatusMessageKey.SelectOrgDirectory),
+            tone = StatusTone.Info,
+        )
+    }
+}
+
+private object DesktopSystemClockEnvironment : ClockEnvironment {
+    override fun now(): Instant = Clock.System.now()
+
+    override fun currentTimeZone(): TimeZone = TimeZone.currentSystemDefault()
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopOpenClockScanner.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopOpenClockScanner.kt
@@ -1,0 +1,94 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.data.ClockRepository
+import com.example.orgclock.model.HeadingPath
+import com.example.orgclock.parser.OrgParser
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaZoneId
+import java.time.ZonedDateTime
+
+data class DesktopFileScanFailure(
+    val fileId: String,
+    val fileName: String,
+    val reason: String,
+)
+
+data class DesktopClockInEntry(
+    val fileId: String,
+    val fileName: String,
+    val headingTitle: String,
+    val l1Title: String?,
+    val headingPath: HeadingPath,
+    val startedAt: ZonedDateTime,
+)
+
+data class DesktopOpenClockScanResult(
+    val entries: List<DesktopClockInEntry>,
+    val failedFiles: List<DesktopFileScanFailure>,
+)
+
+class DesktopOpenClockScanner(
+    private val repository: ClockRepository,
+    private val parser: OrgParser = OrgParser(),
+) {
+    suspend fun scan(timeZone: TimeZone): Result<DesktopOpenClockScanResult> {
+        val files = repository.listOrgFiles().getOrElse { return Result.failure(it) }
+        val entries = mutableListOf<DesktopClockInEntry>()
+        val failures = mutableListOf<DesktopFileScanFailure>()
+
+        for (file in files) {
+            val docResult = repository.loadFile(file.fileId)
+            if (docResult.isFailure) {
+                failures += DesktopFileScanFailure(
+                    fileId = file.fileId,
+                    fileName = file.displayName,
+                    reason = readableFailureReason(docResult.exceptionOrNull()),
+                )
+                continue
+            }
+            val parsed = runCatching { parser.parseHeadingsWithOpenClock(docResult.getOrThrow().lines, timeZone) }
+            if (parsed.isFailure) {
+                failures += DesktopFileScanFailure(
+                    fileId = file.fileId,
+                    fileName = file.displayName,
+                    reason = readableFailureReason(parsed.exceptionOrNull()),
+                )
+                continue
+            }
+
+            entries += parsed.getOrThrow()
+                .asSequence()
+                .filter { it.node.level == 2 && it.openClock != null }
+                .map { heading ->
+                    DesktopClockInEntry(
+                        fileId = file.fileId,
+                        fileName = file.displayName,
+                        headingTitle = heading.node.title,
+                        l1Title = heading.node.parentL1,
+                        headingPath = heading.node.path,
+                        startedAt = heading.openClock!!.toDesktopZonedDateTime(timeZone),
+                    )
+                }
+        }
+
+        return Result.success(
+            DesktopOpenClockScanResult(
+                entries = entries.sortedByDescending { it.startedAt },
+                failedFiles = failures,
+            ),
+        )
+    }
+
+    private fun readableFailureReason(error: Throwable?): String {
+        val message = error?.message?.trim()
+        return if (!message.isNullOrEmpty()) {
+            message
+        } else {
+            error?.javaClass?.simpleName ?: "unknown error"
+        }
+    }
+
+    private fun kotlinx.datetime.Instant.toDesktopZonedDateTime(timeZone: TimeZone): ZonedDateTime =
+        toJavaInstant().atZone(timeZone.toJavaZoneId())
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSettingsStore.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSettingsStore.kt
@@ -1,0 +1,39 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.presentation.RootReference
+import java.util.prefs.Preferences
+
+data class DesktopHostSettings(
+    val lastRootReference: RootReference? = null,
+)
+
+class DesktopSettingsStore(
+    private val preferences: Preferences = Preferences.userRoot().node(PREFERENCES_NODE),
+) {
+    fun load(): DesktopHostSettings {
+        val rawRoot = preferences.get(KEY_LAST_ROOT, null)
+        return DesktopHostSettings(
+            lastRootReference = rawRoot?.takeIf { it.isNotBlank() }?.let(::RootReference),
+        )
+    }
+
+    fun save(settings: DesktopHostSettings) {
+        val root = settings.lastRootReference?.rawValue
+        if (root.isNullOrBlank()) {
+            preferences.remove(KEY_LAST_ROOT)
+        } else {
+            preferences.put(KEY_LAST_ROOT, root)
+        }
+        preferences.flush()
+    }
+
+    fun clear() {
+        preferences.remove(KEY_LAST_ROOT)
+        preferences.flush()
+    }
+
+    private companion object {
+        const val PREFERENCES_NODE = "com/example/orgclock/desktop"
+        const val KEY_LAST_ROOT = "last_root"
+    }
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
@@ -1,33 +1,41 @@
 package com.example.orgclock.desktop
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.example.orgclock.presentation.OrgClockPresentationState
 import com.example.orgclock.presentation.RootReference
-import com.example.orgclock.presentation.Screen
-import com.example.orgclock.presentation.StatusMessageKey
-import com.example.orgclock.presentation.StatusText
-import com.example.orgclock.presentation.StatusTone
 import com.example.orgclock.presentation.UiStatus
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import kotlinx.coroutines.launch
+import javax.swing.JFileChooser
 
 fun main() = application {
     Window(
@@ -40,14 +48,20 @@ fun main() = application {
 
 @Composable
 private fun DesktopApp() {
-    val state = OrgClockPresentationState(
-        screen = Screen.RootSetup,
-        rootReference = RootReference("/home/demo/org"),
-        status = UiStatus(
-            text = StatusText(StatusMessageKey.SelectOrgDirectory),
-            tone = StatusTone.Info,
-        ),
-    )
+    val graph = remember { DesktopAppGraph() }
+    val scope = rememberCoroutineScope()
+    var snapshot by remember {
+        mutableStateOf(
+            DesktopHostSnapshot(
+                presentationState = com.example.orgclock.presentation.OrgClockPresentationState(),
+            ),
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        snapshot = graph.snapshot()
+    }
+
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
             Box(
@@ -73,7 +87,7 @@ private fun DesktopApp() {
                     ),
                 ) {
                     Column(
-                        modifier = Modifier.padding(horizontal = 28.dp, vertical = 32.dp),
+                        modifier = Modifier.padding(horizontal = 28.dp, vertical = 32.dp).fillMaxWidth(),
                         horizontalAlignment = Alignment.Start,
                         verticalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
@@ -83,17 +97,112 @@ private fun DesktopApp() {
                             fontWeight = FontWeight.SemiBold,
                         )
                         Text(
-                            text = "Shared presentation contract loads on desktop without Android framework types.",
+                            text = "Desktop composition root restores the saved org root and wires JVM-only dependencies.",
                             style = MaterialTheme.typography.bodyLarge,
                         )
+                        StatusChip(status = snapshot.presentationState.status)
                         Text(
-                            text = "screen=${state.screen} | root=${state.rootReference?.rawValue}",
+                            text = "screen=${snapshot.presentationState.screen}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color(0xFFD3E6D6),
+                        )
+                        Text(
+                            text = snapshot.presentationState.rootReference?.rawValue ?: "No org root selected",
                             style = MaterialTheme.typography.bodyMedium,
                             color = Color(0xFFD3E6D6),
                         )
+                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            Button(
+                                onClick = {
+                                    chooseRootDirectory(snapshot.presentationState.rootReference)?.let { root ->
+                                        scope.launch {
+                                            graph.openRoot(root)
+                                            snapshot = graph.snapshot()
+                                        }
+                                    }
+                                },
+                            ) {
+                                Text("Select org root")
+                            }
+                            Button(
+                                onClick = {
+                                    scope.launch {
+                                        snapshot = graph.snapshot()
+                                    }
+                                },
+                            ) {
+                                Text("Reload")
+                            }
+                        }
+                        HorizontalDivider(color = Color(0xFF3B564F))
+                        Text(
+                            text = "Files: ${snapshot.files.size} | Running: ${snapshot.openClockCount} | Scan failures: ${snapshot.fileFailureCount}",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        if (snapshot.files.isEmpty()) {
+                            Text(
+                                text = "No org files loaded yet. Select a root to restore or inspect the MVP workspace.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color(0xFFD3E6D6),
+                            )
+                        } else {
+                            snapshot.files.take(6).forEach { file ->
+                                val running = if (file.fileId in snapshot.filesWithOpenClock) "running" else "idle"
+                                Text(
+                                    text = "${file.displayName} [$running]",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .border(1.dp, Color(0xFF3B564F), RoundedCornerShape(12.dp))
+                                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                                )
+                            }
+                            if (snapshot.files.size > 6) {
+                                Text(
+                                    text = "+${snapshot.files.size - 6} more files",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = Color(0xFFD3E6D6),
+                                )
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun StatusChip(status: UiStatus) {
+    val label = when (status.text.key) {
+        com.example.orgclock.presentation.StatusMessageKey.SelectOrgDirectory -> "Select an org root to begin."
+        com.example.orgclock.presentation.StatusMessageKey.RootSet -> "Root restored and ready."
+        com.example.orgclock.presentation.StatusMessageKey.FailedOpenRoot -> "Saved root could not be opened: ${status.text.args.firstOrNull().orEmpty()}"
+        com.example.orgclock.presentation.StatusMessageKey.FailedListingFiles -> "File listing failed: ${status.text.args.firstOrNull().orEmpty()}"
+        else -> "${status.text.key}: ${status.text.args.joinToString()}"
+    }
+    val color = when (status.tone) {
+        com.example.orgclock.presentation.StatusTone.Info -> Color(0xFFB9D3C2)
+        com.example.orgclock.presentation.StatusTone.Success -> Color(0xFF8FE0A8)
+        com.example.orgclock.presentation.StatusTone.Warning -> Color(0xFFF2D38A)
+        com.example.orgclock.presentation.StatusTone.Error -> Color(0xFFF5A3A3)
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = color,
+    )
+}
+
+private fun chooseRootDirectory(currentRoot: RootReference?): RootReference? {
+    val chooser = JFileChooser(currentRoot?.rawValue).apply {
+        dialogTitle = "Select Org Clock root"
+        fileSelectionMode = JFileChooser.DIRECTORIES_ONLY
+        isAcceptAllFileFilterUsed = false
+    }
+    return if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+        chooser.selectedFile?.toPath()?.toAbsolutePath()?.normalize()?.toString()?.let(::RootReference)
+    } else {
+        null
     }
 }

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopAppGraphTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopAppGraphTest.kt
@@ -1,0 +1,85 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.presentation.RootReference
+import com.example.orgclock.presentation.Screen
+import com.example.orgclock.presentation.StatusMessageKey
+import kotlinx.coroutines.test.runTest
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.prefs.Preferences
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopAppGraphTest {
+    private val tempRoots = mutableListOf<Path>()
+    private val nodes = mutableListOf<Preferences>()
+
+    @AfterTest
+    fun cleanup() {
+        tempRoots.asReversed().forEach { root ->
+            Files.walk(root).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+            }
+        }
+        tempRoots.clear()
+        nodes.asReversed().forEach { node ->
+            runCatching {
+                node.removeNode()
+                node.parent()?.flush()
+            }
+        }
+        nodes.clear()
+    }
+
+    @Test
+    fun restoresSavedRootOnStartup() = runTest {
+        val root = tempRoot()
+        write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
+        val store = DesktopSettingsStore(testNode())
+        store.save(DesktopHostSettings(lastRootReference = RootReference(root.toString())))
+
+        val graph = DesktopAppGraph(settingsStore = store)
+        val snapshot = graph.snapshot()
+
+        assertEquals(Screen.FilePicker, snapshot.presentationState.screen)
+        assertEquals(root.toString(), snapshot.presentationState.rootReference?.rawValue)
+        assertEquals(StatusMessageKey.RootSet, snapshot.presentationState.status.text.key)
+        assertEquals(1, snapshot.files.size)
+    }
+
+    @Test
+    fun dependenciesProvideDesktopClockOperations() = runTest {
+        val root = tempRoot()
+        write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
+        val graph = DesktopAppGraph(settingsStore = DesktopSettingsStore(testNode()))
+        val dependencies = graph.dependencies()
+
+        assertTrue(dependencies.openRoot(RootReference(root.toString())).isSuccess)
+
+        val files = dependencies.listFiles().getOrThrow()
+        assertEquals(1, files.size)
+
+        val file = files.single()
+        assertTrue(
+            dependencies.startClock(file.fileId, com.example.orgclock.model.HeadingPath.parse("Work/Task")).isSuccess,
+        )
+
+        val filesWithOpenClock = dependencies.listFilesWithOpenClock().getOrThrow()
+        assertEquals(setOf(file.fileId), filesWithOpenClock)
+    }
+
+    private fun tempRoot(): Path = createTempDirectory("desktop-graph-test").also(tempRoots::add)
+
+    private fun testNode(): Preferences =
+        Preferences.userRoot()
+            .node("com/example/orgclock/desktop/test/${System.nanoTime()}")
+            .also(nodes::add)
+
+    private fun write(path: Path, text: String) {
+        Files.writeString(path, text, StandardCharsets.UTF_8)
+    }
+}

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSettingsStoreTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSettingsStoreTest.kt
@@ -1,0 +1,48 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.presentation.RootReference
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import java.util.prefs.Preferences
+
+class DesktopSettingsStoreTest {
+    private val nodes = mutableListOf<Preferences>()
+
+    @AfterTest
+    fun cleanup() {
+        nodes.asReversed().forEach { node ->
+            runCatching {
+                node.removeNode()
+                node.parent()?.flush()
+            }
+        }
+        nodes.clear()
+    }
+
+    @Test
+    fun saveAndLoad_lastRootReference() {
+        val store = DesktopSettingsStore(testNode())
+
+        store.save(DesktopHostSettings(lastRootReference = RootReference("/tmp/org-root")))
+
+        val loaded = store.load()
+        assertEquals("/tmp/org-root", loaded.lastRootReference?.rawValue)
+    }
+
+    @Test
+    fun clear_removesPersistedRoot() {
+        val store = DesktopSettingsStore(testNode())
+        store.save(DesktopHostSettings(lastRootReference = RootReference("/tmp/org-root")))
+
+        store.clear()
+
+        assertNull(store.load().lastRootReference)
+    }
+
+    private fun testNode(): Preferences =
+        Preferences.userRoot()
+            .node("com/example/orgclock/desktop/test/${System.nanoTime()}")
+            .also(nodes::add)
+}


### PR DESCRIPTION
## Summary
- add a desktop app graph that restores and persists the local org root
- wire the desktop JVM host to repository, clock service, and open-clock scanning dependencies
- replace the desktop placeholder with a host UI that can select and reload the configured root

## Testing
- ./gradlew :desktopApp:compileKotlin :desktopApp:test :shared:compileKotlinJvm