### PR TITLE
Fix auto-generation success detection

### DIFF
--- a/app/src/test/java/com/example/orgclock/template/TemplateAutoGenerationSchedulerTest.kt
+++ b/app/src/test/java/com/example/orgclock/template/TemplateAutoGenerationSchedulerTest.kt
@@ -108,6 +108,50 @@ class TemplateAutoGenerationSchedulerTest {
     }
 
     @Test
+    fun runWorker_doesNotMarkSuccessWhenGenerationFails() = runTest {
+        val prefs = FakeSharedPreferences()
+        val store = RootScheduleStore(prefs)
+        val reporter = FakeFailureReporter()
+        val runtimeStore = FakeRuntimeStore().apply {
+            state = TemplateAutoGenerationRuntimeState(lastSuccessAtEpochMs = 123L)
+        }
+        val workScheduler = FakeWorkScheduler()
+        val repository = FakeTemplateRepository(
+            generationResult = TemplateGenerationResult.Failed(
+                reason = "File changed by another process.",
+                kind = TemplateGenerationFailureKind.SaveFailed,
+            ),
+        )
+        val rootUri = "content://orgclock/root"
+        store.save(
+            RootScheduleConfig(
+                rootUri = rootUri,
+                enabled = true,
+                hour = 9,
+                minute = 0,
+            ),
+        )
+        val rootUriRef = mock(android.net.Uri::class.java).apply {
+            doReturn(rootUri).`when`(this).toString()
+        }
+        val scheduler = TemplateAutoGenerationScheduler(
+            appContext = mock(android.content.Context::class.java),
+            scheduleStore = store,
+            failureReporter = reporter,
+            runtimeStore = runtimeStore,
+            repositoryFactory = { repository },
+            workScheduler = workScheduler,
+            logError = {},
+            nowProvider = { ZonedDateTime.of(2026, 3, 12, 9, 30, 0, 0, ZoneId.of("Asia/Tokyo")) },
+        )
+
+        scheduler.runWorker(rootUriRef)
+
+        assertEquals(123L, runtimeStore.state.lastSuccessAtEpochMs)
+        assertEquals("File changed by another process.", reporter.lastMessage)
+    }
+
+    @Test
     fun runCatchUpIfDue_generatesMissingTodayFileAndMarksStateOverdueFalse() = runTest {
         val prefs = FakeSharedPreferences()
         val store = RootScheduleStore(prefs)

--- a/shared/src/androidMain/kotlin/com/example/orgclock/data/SafOrgRepository.kt
+++ b/shared/src/androidMain/kotlin/com/example/orgclock/data/SafOrgRepository.kt
@@ -304,20 +304,11 @@ class SafOrgRepository(
                 )
             }
 
-            when (val save = saveDaily(date, templateDoc.lines, expectedHash = "")) {
-                is SaveResult.Success -> TemplateGenerationResult.Generated
-                is SaveResult.Conflict -> TemplateGenerationResult.SkippedDailyAlreadyExists
-                is SaveResult.ValidationError -> TemplateGenerationResult.Failed(
-                    reason = save.reason,
-                    kind = TemplateGenerationFailureKind.SaveFailed,
-                    templateStatus = templateStatus,
-                )
-                is SaveResult.IoError -> TemplateGenerationResult.Failed(
-                    reason = save.reason,
-                    kind = TemplateGenerationFailureKind.SaveFailed,
-                    templateStatus = templateStatus,
-                )
-            }
+            val expectedHash = expectedHashForMissingDocument()
+            saveResultToTemplateGenerationResult(
+                save = saveDaily(date, templateDoc.lines, expectedHash = expectedHash),
+                templateStatus = templateStatus,
+            )
         }
     }
 
@@ -465,4 +456,33 @@ class SafOrgRepository(
     }
 
     companion object
+}
+
+internal fun expectedHashForMissingDocument(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest("".toByteArray())
+    return digest.joinToString("") { "%02x".format(it) }
+}
+
+internal fun saveResultToTemplateGenerationResult(
+    save: SaveResult,
+    templateStatus: TemplateFileStatus,
+): TemplateGenerationResult {
+    return when (save) {
+        SaveResult.Success -> TemplateGenerationResult.Generated
+        is SaveResult.Conflict -> TemplateGenerationResult.Failed(
+            reason = save.reason,
+            kind = TemplateGenerationFailureKind.SaveFailed,
+            templateStatus = templateStatus,
+        )
+        is SaveResult.ValidationError -> TemplateGenerationResult.Failed(
+            reason = save.reason,
+            kind = TemplateGenerationFailureKind.SaveFailed,
+            templateStatus = templateStatus,
+        )
+        is SaveResult.IoError -> TemplateGenerationResult.Failed(
+            reason = save.reason,
+            kind = TemplateGenerationFailureKind.SaveFailed,
+            templateStatus = templateStatus,
+        )
+    }
 }

--- a/shared/src/androidUnitTest/kotlin/com/example/orgclock/data/SafOrgRepositoryTemplateGenerationTest.kt
+++ b/shared/src/androidUnitTest/kotlin/com/example/orgclock/data/SafOrgRepositoryTemplateGenerationTest.kt
@@ -1,0 +1,39 @@
+package com.example.orgclock.data
+
+import com.example.orgclock.template.TemplateAvailability
+import com.example.orgclock.template.TemplateFileStatus
+import com.example.orgclock.template.TemplateGenerationFailureKind
+import com.example.orgclock.template.TemplateGenerationResult
+import com.example.orgclock.template.TemplateReferenceMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SafOrgRepositoryTemplateGenerationTest {
+    @Test
+    fun expectedHashForMissingDocument_matchesEmptyContentHash() {
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            expectedHashForMissingDocument(),
+        )
+    }
+
+    @Test
+    fun saveResultConflict_isReportedAsFailureInsteadOfAlreadyExisting() {
+        val templateStatus = TemplateFileStatus(
+            availability = TemplateAvailability.Available,
+            referenceMode = TemplateReferenceMode.LegacyHiddenFile,
+        )
+
+        val result = saveResultToTemplateGenerationResult(
+            save = SaveResult.Conflict("File changed by another process."),
+            templateStatus = templateStatus,
+        )
+
+        assertTrue(result is TemplateGenerationResult.Failed)
+        result as TemplateGenerationResult.Failed
+        assertEquals("File changed by another process.", result.reason)
+        assertEquals(TemplateGenerationFailureKind.SaveFailed, result.kind)
+        assertEquals(templateStatus, result.templateStatus)
+    }
+}


### PR DESCRIPTION
## Summary
- fix daily auto-generation to use the empty-document hash when creating a missing file
- treat save conflicts as generation failures instead of as already-existing daily files
- add regression tests for repository mapping and scheduler success timestamp handling

## Testing
- ./gradlew :shared:testDebugUnitTest --tests com.example.orgclock.data.SafOrgRepositoryTemplateGenerationTest :app:testDebugUnitTest --tests com.example.orgclock.template.TemplateAutoGenerationSchedulerTest