### PR TITLE
[codex] Fix sync store threading and stabilize Windows Android tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,9 +92,9 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestUtil("androidx.test:orchestrator:1.5.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+    androidTestUtil("androidx.test:orchestrator:1.6.1")
 
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")

--- a/app/src/androidTest/java/com/example/orgclock/domain/ClockServiceRecorderMainThreadTest.kt
+++ b/app/src/androidTest/java/com/example/orgclock/domain/ClockServiceRecorderMainThreadTest.kt
@@ -40,7 +40,10 @@ class ClockServiceRecorderMainThreadTest {
                 repository = singleFileRepo(
                     initialLines = listOf("* Work", "** Project A", ":LOGBOOK:", ":END:"),
                 ),
-                clockEventRecorder = StoreBackedClockEventRecorder(startStore),
+                clockEventRecorder = StoreBackedClockEventRecorder(
+                    store = startStore,
+                    deviceIdProvider = { "device-local" },
+                ),
             )
 
             val startResult = startService.startClockInFile(
@@ -66,7 +69,10 @@ class ClockServiceRecorderMainThreadTest {
                         ":END:",
                     ),
                 ),
-                clockEventRecorder = StoreBackedClockEventRecorder(stopStore),
+                clockEventRecorder = StoreBackedClockEventRecorder(
+                    store = stopStore,
+                    deviceIdProvider = { "device-local" },
+                ),
             )
 
             val stopResult = stopService.stopClockInFile(
@@ -92,7 +98,10 @@ class ClockServiceRecorderMainThreadTest {
                         ":END:",
                     ),
                 ),
-                clockEventRecorder = StoreBackedClockEventRecorder(cancelStore),
+                clockEventRecorder = StoreBackedClockEventRecorder(
+                    store = cancelStore,
+                    deviceIdProvider = { "device-local" },
+                ),
             )
 
             val cancelResult = cancelService.cancelClockInFile(

--- a/app/src/androidTest/java/com/example/orgclock/domain/ClockServiceRecorderMainThreadTest.kt
+++ b/app/src/androidTest/java/com/example/orgclock/domain/ClockServiceRecorderMainThreadTest.kt
@@ -1,0 +1,134 @@
+package com.example.orgclock.domain
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.orgclock.data.ClockRepository
+import com.example.orgclock.data.FileWriteIntent
+import com.example.orgclock.data.OrgFileEntry
+import com.example.orgclock.data.SaveResult
+import com.example.orgclock.model.HeadingPath
+import com.example.orgclock.model.OrgDocument
+import com.example.orgclock.sync.ClockEventDatabase
+import com.example.orgclock.sync.ClockEventType
+import com.example.orgclock.sync.RoomClockEventStore
+import com.example.orgclock.sync.StoreBackedClockEventRecorder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ClockServiceRecorderMainThreadTest {
+
+    @Test
+    fun startStopCancel_recordEventsSuccessfullyFromMainThread() = runBlocking(Dispatchers.Main) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+        fun newStore(): Pair<ClockEventDatabase, RoomClockEventStore> {
+            val database = Room.inMemoryDatabaseBuilder(context, ClockEventDatabase::class.java).build()
+            return database to RoomClockEventStore(database.dao())
+        }
+
+        val (startDb, startStore) = newStore()
+        try {
+            val startService = ClockService(
+                repository = singleFileRepo(
+                    initialLines = listOf("* Work", "** Project A", ":LOGBOOK:", ":END:"),
+                ),
+                clockEventRecorder = StoreBackedClockEventRecorder(startStore),
+            )
+
+            val startResult = startService.startClockInFile(
+                fileId = "f1",
+                headingPath = HeadingPath.parse("Work/Project A"),
+                now = Instant.parse("2026-03-18T09:00:00Z"),
+            )
+            assertTrue(startResult.isSuccess)
+            assertEquals(listOf(ClockEventType.Started), startStore.readAllForReplay().map { it.event.eventType })
+        } finally {
+            startDb.close()
+        }
+
+        val (stopDb, stopStore) = newStore()
+        try {
+            val stopService = ClockService(
+                repository = singleFileRepo(
+                    initialLines = listOf(
+                        "* Work",
+                        "** Project A",
+                        ":LOGBOOK:",
+                        "CLOCK: [2026-03-18 Tue 09:00:00]",
+                        ":END:",
+                    ),
+                ),
+                clockEventRecorder = StoreBackedClockEventRecorder(stopStore),
+            )
+
+            val stopResult = stopService.stopClockInFile(
+                fileId = "f1",
+                headingPath = HeadingPath.parse("Work/Project A"),
+                now = Instant.parse("2026-03-18T10:00:00Z"),
+            )
+            assertTrue(stopResult.isSuccess)
+            assertEquals(listOf(ClockEventType.Stopped), stopStore.readAllForReplay().map { it.event.eventType })
+        } finally {
+            stopDb.close()
+        }
+
+        val (cancelDb, cancelStore) = newStore()
+        try {
+            val cancelService = ClockService(
+                repository = singleFileRepo(
+                    initialLines = listOf(
+                        "* Work",
+                        "** Project A",
+                        ":LOGBOOK:",
+                        "CLOCK: [2026-03-18 Tue 09:00:00]",
+                        ":END:",
+                    ),
+                ),
+                clockEventRecorder = StoreBackedClockEventRecorder(cancelStore),
+            )
+
+            val cancelResult = cancelService.cancelClockInFile(
+                fileId = "f1",
+                headingPath = HeadingPath.parse("Work/Project A"),
+            )
+            assertTrue(cancelResult.isSuccess)
+            assertEquals(listOf(ClockEventType.Cancelled), cancelStore.readAllForReplay().map { it.event.eventType })
+        } finally {
+            cancelDb.close()
+        }
+    }
+
+    private fun singleFileRepo(initialLines: List<String>): ClockRepository = object : ClockRepository {
+        private var currentLines = initialLines
+
+        override suspend fun listOrgFiles(): Result<List<OrgFileEntry>> =
+            Result.success(listOf(OrgFileEntry("f1", "f1.org", null)))
+
+        override suspend fun loadFile(fileId: String): Result<OrgDocument> =
+            Result.success(OrgDocument(LocalDate(2026, 3, 18), currentLines, "hash"))
+
+        override suspend fun saveFile(
+            fileId: String,
+            lines: List<String>,
+            expectedHash: String,
+            writeIntent: FileWriteIntent,
+        ): SaveResult {
+            currentLines = lines
+            return SaveResult.Success
+        }
+
+        override suspend fun loadDaily(date: LocalDate): Result<OrgDocument> =
+            Result.failure(UnsupportedOperationException())
+
+        override suspend fun saveDaily(date: LocalDate, lines: List<String>, expectedHash: String): SaveResult =
+            SaveResult.ValidationError("unsupported")
+    }
+}

--- a/app/src/androidTest/java/com/example/orgclock/sync/RoomClockEventStoreMainThreadTest.kt
+++ b/app/src/androidTest/java/com/example/orgclock/sync/RoomClockEventStoreMainThreadTest.kt
@@ -1,0 +1,58 @@
+package com.example.orgclock.sync
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.orgclock.model.HeadingPath
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RoomClockEventStoreMainThreadTest {
+
+    @Test
+    fun storeOperations_succeedWhenCalledFromMainThread() = runBlocking(Dispatchers.Main) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        val database = Room.inMemoryDatabaseBuilder(context, ClockEventDatabase::class.java).build()
+        try {
+            val store = RoomClockEventStore(database.dao())
+            val event = sampleEvent("evt-1", 1L)
+
+            val appendResult = store.append(event)
+            assertTrue(appendResult is AppendClockEventResult.Appended)
+            val appendedCursor = (appendResult as AppendClockEventResult.Appended).cursor
+            assertEquals(ClockEventCursor(1L), appendedCursor)
+
+            val duplicateResult = store.append(event)
+            assertTrue(duplicateResult is AppendClockEventResult.Duplicate)
+            assertEquals(appendedCursor, (duplicateResult as AppendClockEventResult.Duplicate).cursor)
+
+            assertTrue(store.contains("evt-1"))
+            assertEquals(listOf("evt-1"), store.readAllForReplay().map { it.event.eventId })
+            assertEquals(1, store.readSnapshot().pendingSyncCount)
+            assertEquals(listOf("evt-1"), store.listSince(null).map { it.event.eventId })
+
+            store.updateSyncCheckpoint(appendedCursor)
+            assertEquals(appendedCursor, store.readSnapshot().lastSyncedCursor)
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun sampleEvent(eventId: String, counter: Long): ClockEvent = ClockEvent(
+        eventId = eventId,
+        eventType = ClockEventType.Started,
+        deviceId = "device-local",
+        createdAt = Instant.parse("2026-03-18T09:00:00Z"),
+        logicalDay = LocalDate.parse("2026-03-18"),
+        fileName = "2026-03-18.org",
+        headingPath = HeadingPath.parse("Work/Project A"),
+        causalOrder = ClockEventCausalOrder(counter = counter),
+    )
+}

--- a/app/src/androidTest/java/com/example/orgclock/sync/RoomCommandIdStoreMainThreadTest.kt
+++ b/app/src/androidTest/java/com/example/orgclock/sync/RoomCommandIdStoreMainThreadTest.kt
@@ -1,0 +1,45 @@
+package com.example.orgclock.sync
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RoomCommandIdStoreMainThreadTest {
+
+    @Test
+    fun storeOperations_succeedWhenCalledFromMainThread() = runBlocking(Dispatchers.Main) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        val database = Room.inMemoryDatabaseBuilder(context, ProcessedCommandIdDatabase::class.java).build()
+        try {
+            val store = RoomCommandIdStore(
+                dao = database.dao(),
+                nowEpochMs = { 10_000L },
+                retentionMs = 1_000L,
+                maxRows = 3L,
+            )
+
+            assertFalse(store.contains("cmd-1"))
+            store.markProcessed("cmd-1")
+            assertTrue(store.contains("cmd-1"))
+            assertTrue(store.size() >= 1L)
+
+            store.markProcessed("cmd-2")
+            store.markProcessed("cmd-3")
+            store.markProcessed("cmd-4")
+
+            assertFalse(store.contains("cmd-1"))
+            assertTrue(store.contains("cmd-2"))
+            assertTrue(store.contains("cmd-3"))
+            assertTrue(store.contains("cmd-4"))
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/main/java/com/example/orgclock/OrgClockApplication.kt
+++ b/app/src/main/java/com/example/orgclock/OrgClockApplication.kt
@@ -1,6 +1,7 @@
 package com.example.orgclock
 
 import android.app.Application
+import android.os.StrictMode
 import com.example.orgclock.di.AppGraph
 import com.example.orgclock.di.DefaultAppGraph
 
@@ -9,6 +10,16 @@ class OrgClockApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectDiskReads()
+                    .detectDiskWrites()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build(),
+            )
+        }
         appGraph.syncIntegrationService().onAppStarted()
         appGraph.androidEventSyncRuntime().onAppStarted()
     }

--- a/app/src/main/java/com/example/orgclock/OrgClockApplication.kt
+++ b/app/src/main/java/com/example/orgclock/OrgClockApplication.kt
@@ -4,9 +4,14 @@ import android.app.Application
 import android.os.StrictMode
 import com.example.orgclock.di.AppGraph
 import com.example.orgclock.di.DefaultAppGraph
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 class OrgClockApplication : Application() {
     val appGraph: AppGraph by lazy { DefaultAppGraph(applicationContext) }
+    private val startupScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun onCreate() {
         super.onCreate()
@@ -20,7 +25,9 @@ class OrgClockApplication : Application() {
                     .build(),
             )
         }
-        appGraph.syncIntegrationService().onAppStarted()
-        appGraph.androidEventSyncRuntime().onAppStarted()
+        startupScope.launch {
+            appGraph.syncIntegrationService().onAppStarted()
+            appGraph.androidEventSyncRuntime().onAppStarted()
+        }
     }
 }

--- a/app/src/main/java/com/example/orgclock/di/AppGraph.kt
+++ b/app/src/main/java/com/example/orgclock/di/AppGraph.kt
@@ -61,8 +61,10 @@ import com.example.orgclock.time.toKotlinInstantCompat
 import com.example.orgclock.time.today
 import kotlinx.datetime.toJavaZoneId
 import com.example.orgclock.ui.app.OrgClockRouteDependencies
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
 
 interface AppGraph {
     fun routeDependencies(
@@ -241,12 +243,14 @@ class DefaultAppGraph(
             },
             listHeadings = { fileId -> clockService.listHeadings(fileId, clockEnvironment.currentTimeZone()) },
             startClock = { fileId, headingPath ->
-                val result = clockService.startClockInFile(
-                    fileId,
-                    headingPath,
-                    clockEnvironment.now(),
-                    clockEnvironment.currentTimeZone(),
-                )
+                val result = withContext(Dispatchers.IO) {
+                    clockService.startClockInFile(
+                        fileId,
+                        headingPath,
+                        clockEnvironment.now(),
+                        clockEnvironment.currentTimeZone(),
+                    )
+                }
                 publishIfSaved(
                     result = result,
                     kind = ClockCommandKind.Start,
@@ -256,12 +260,14 @@ class DefaultAppGraph(
                 )
             },
             stopClock = { fileId, headingPath ->
-                val result = clockService.stopClockInFile(
-                    fileId,
-                    headingPath,
-                    clockEnvironment.now(),
-                    clockEnvironment.currentTimeZone(),
-                )
+                val result = withContext(Dispatchers.IO) {
+                    clockService.stopClockInFile(
+                        fileId,
+                        headingPath,
+                        clockEnvironment.now(),
+                        clockEnvironment.currentTimeZone(),
+                    )
+                }
                 publishIfSaved(
                     result = result,
                     kind = ClockCommandKind.Stop,
@@ -271,7 +277,9 @@ class DefaultAppGraph(
                 )
             },
             cancelClock = { fileId, headingPath ->
-                val result = clockService.cancelClockInFile(fileId, headingPath)
+                val result = withContext(Dispatchers.IO) {
+                    clockService.cancelClockInFile(fileId, headingPath)
+                }
                 publishIfSaved(
                     result = result,
                     kind = ClockCommandKind.Cancel,

--- a/app/src/main/java/com/example/orgclock/sync/CommandIdStore.kt
+++ b/app/src/main/java/com/example/orgclock/sync/CommandIdStore.kt
@@ -3,28 +3,28 @@ package com.example.orgclock.sync
 import android.content.SharedPreferences
 
 interface CommandIdStore {
-    fun contains(commandId: String): Boolean
-    fun markProcessed(commandId: String)
-    fun pruneOlderThan(epochMs: Long): Int = 0
-    fun size(): Long = 0L
+    suspend fun contains(commandId: String): Boolean
+    suspend fun markProcessed(commandId: String)
+    suspend fun pruneOlderThan(epochMs: Long): Int = 0
+    suspend fun size(): Long = 0L
 }
 
 class SharedPreferencesCommandIdStore(
     private val sharedPreferences: SharedPreferences,
 ) : CommandIdStore {
-    override fun contains(commandId: String): Boolean {
+    override suspend fun contains(commandId: String): Boolean {
         return sharedPreferences.getStringSet(KEY_PROCESSED_COMMAND_IDS, emptySet())
             ?.contains(commandId) == true
     }
 
-    override fun markProcessed(commandId: String) {
+    override suspend fun markProcessed(commandId: String) {
         val existing = sharedPreferences.getStringSet(KEY_PROCESSED_COMMAND_IDS, emptySet()) ?: emptySet()
         if (existing.contains(commandId)) return
         val updated = existing.toMutableSet().apply { add(commandId) }
         sharedPreferences.edit().putStringSet(KEY_PROCESSED_COMMAND_IDS, updated).apply()
     }
 
-    override fun size(): Long {
+    override suspend fun size(): Long {
         return (sharedPreferences.getStringSet(KEY_PROCESSED_COMMAND_IDS, emptySet()) ?: emptySet()).size.toLong()
     }
 
@@ -36,9 +36,9 @@ class SharedPreferencesCommandIdStore(
 class InMemoryCommandIdStore : CommandIdStore {
     private val processed = linkedSetOf<String>()
 
-    override fun contains(commandId: String): Boolean = processed.contains(commandId)
+    override suspend fun contains(commandId: String): Boolean = processed.contains(commandId)
 
-    override fun markProcessed(commandId: String) {
+    override suspend fun markProcessed(commandId: String) {
         if (processed.contains(commandId)) return
         if (processed.size >= MAX_IN_MEMORY_IDS) {
             val oldest = processed.firstOrNull()
@@ -49,7 +49,7 @@ class InMemoryCommandIdStore : CommandIdStore {
         processed.add(commandId)
     }
 
-    override fun size(): Long = processed.size.toLong()
+    override suspend fun size(): Long = processed.size.toLong()
 
     private companion object {
         const val MAX_IN_MEMORY_IDS = 2_048

--- a/app/src/main/java/com/example/orgclock/sync/RoomClockEventStore.kt
+++ b/app/src/main/java/com/example/orgclock/sync/RoomClockEventStore.kt
@@ -12,6 +12,8 @@ import androidx.room.Query
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.example.orgclock.model.HeadingPath
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 
@@ -101,43 +103,55 @@ internal class RoomClockEventStore(
     private val dao: ClockEventDao,
 ) : ClockEventStore {
     override suspend fun append(event: ClockEvent): AppendClockEventResult {
-        val inserted = dao.insert(event.toEntity())
-        if (inserted != -1L) {
-            return AppendClockEventResult.Appended(ClockEventCursor(inserted))
+        return withContext(Dispatchers.IO) {
+            val inserted = dao.insert(event.toEntity())
+            if (inserted != -1L) {
+                return@withContext AppendClockEventResult.Appended(ClockEventCursor(inserted))
+            }
+            AppendClockEventResult.Duplicate(
+                dao.findCursorByEventId(event.eventId)?.let(::ClockEventCursor),
+            )
         }
-        return AppendClockEventResult.Duplicate(
-            dao.findCursorByEventId(event.eventId)?.let(::ClockEventCursor),
-        )
     }
 
-    override suspend fun contains(eventId: String): Boolean = dao.exists(eventId)
+    override suspend fun contains(eventId: String): Boolean = withContext(Dispatchers.IO) {
+        dao.exists(eventId)
+    }
 
-    override suspend fun readAllForReplay(): List<StoredClockEvent> = dao.readAll().map { it.toStoredEvent() }
+    override suspend fun readAllForReplay(): List<StoredClockEvent> = withContext(Dispatchers.IO) {
+        dao.readAll().map { it.toStoredEvent() }
+    }
 
     override suspend fun listSince(
         cursorExclusive: ClockEventCursor?,
         limit: Int,
     ): List<StoredClockEvent> {
         require(limit > 0) { "List limit must be > 0." }
-        return dao.listSince(cursorExclusive?.value ?: 0L, limit).map { it.toStoredEvent() }
+        return withContext(Dispatchers.IO) {
+            dao.listSince(cursorExclusive?.value ?: 0L, limit).map { it.toStoredEvent() }
+        }
     }
 
     override suspend fun readSnapshot(): ClockEventStoreSnapshot {
-        val lastCursor = dao.findLastCursor()?.let(::ClockEventCursor)
-        val lastSyncedCursor = dao.readSyncState()?.lastSyncedCursor?.let(::ClockEventCursor)
-        val pendingSyncCount = dao.countAfter(lastSyncedCursor?.value ?: 0L)
-        return ClockEventStoreSnapshot(
-            lastCursor = lastCursor,
-            lastSyncedCursor = lastSyncedCursor,
-            pendingSyncCount = pendingSyncCount,
-        )
+        return withContext(Dispatchers.IO) {
+            val lastCursor = dao.findLastCursor()?.let(::ClockEventCursor)
+            val lastSyncedCursor = dao.readSyncState()?.lastSyncedCursor?.let(::ClockEventCursor)
+            val pendingSyncCount = dao.countAfter(lastSyncedCursor?.value ?: 0L)
+            ClockEventStoreSnapshot(
+                lastCursor = lastCursor,
+                lastSyncedCursor = lastSyncedCursor,
+                pendingSyncCount = pendingSyncCount,
+            )
+        }
     }
 
     override suspend fun updateSyncCheckpoint(cursorInclusive: ClockEventCursor) {
-        require(dao.cursorExists(cursorInclusive.value)) {
-            "Cannot update sync checkpoint for unknown cursor ${cursorInclusive.value}."
+        withContext(Dispatchers.IO) {
+            require(dao.cursorExists(cursorInclusive.value)) {
+                "Cannot update sync checkpoint for unknown cursor ${cursorInclusive.value}."
+            }
+            dao.saveSyncState(ClockEventSyncStateEntity(lastSyncedCursor = cursorInclusive.value))
         }
-        dao.saveSyncState(ClockEventSyncStateEntity(lastSyncedCursor = cursorInclusive.value))
     }
 
     companion object {

--- a/app/src/main/java/com/example/orgclock/sync/RoomCommandIdStore.kt
+++ b/app/src/main/java/com/example/orgclock/sync/RoomCommandIdStore.kt
@@ -10,6 +10,8 @@ import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 
 @Entity(tableName = "processed_command_ids")
@@ -57,25 +59,31 @@ internal class RoomCommandIdStore(
     private val retentionMs: Long = TimeUnit.DAYS.toMillis(7),
     private val maxRows: Long = 20_000L,
 ) : CommandIdStore {
-    override fun contains(commandId: String): Boolean = dao.exists(commandId)
+    override suspend fun contains(commandId: String): Boolean = withContext(Dispatchers.IO) { dao.exists(commandId) }
 
-    override fun markProcessed(commandId: String) {
-        dao.insert(
-            ProcessedCommandIdEntity(
-                commandId = commandId,
-                processedAtEpochMs = nowEpochMs(),
-            ),
-        )
-        pruneInternal()
+    override suspend fun markProcessed(commandId: String) {
+        withContext(Dispatchers.IO) {
+            dao.insert(
+                ProcessedCommandIdEntity(
+                    commandId = commandId,
+                    processedAtEpochMs = nowEpochMs(),
+                ),
+            )
+            pruneInternal()
+        }
     }
 
-    override fun pruneOlderThan(epochMs: Long): Int = dao.deleteOlderThan(epochMs)
+    override suspend fun pruneOlderThan(epochMs: Long): Int = withContext(Dispatchers.IO) {
+        dao.deleteOlderThan(epochMs)
+    }
 
-    override fun size(): Long = dao.count()
+    override suspend fun size(): Long = withContext(Dispatchers.IO) {
+        dao.count()
+    }
 
-    private fun pruneInternal() {
-        pruneOlderThan(nowEpochMs() - retentionMs)
-        val overflow = size() - maxRows
+    private suspend fun pruneInternal() {
+        dao.deleteOlderThan(nowEpochMs() - retentionMs)
+        val overflow = dao.count() - maxRows
         if (overflow > 0) {
             dao.deleteOldest(overflow.toInt())
         }

--- a/app/src/test/java/com/example/orgclock/sync/DefaultClockCommandExecutorTest.kt
+++ b/app/src/test/java/com/example/orgclock/sync/DefaultClockCommandExecutorTest.kt
@@ -385,14 +385,16 @@ class DefaultClockCommandExecutorTest {
 
     @Test
     fun inMemoryCommandIdStore_evictsOldIdsWhenCapacityExceeded() {
-        val store = InMemoryCommandIdStore()
+        runBlocking {
+            val store = InMemoryCommandIdStore()
 
-        repeat(3_000) { index ->
-            store.markProcessed("cmd-$index")
+            repeat(3_000) { index ->
+                store.markProcessed("cmd-$index")
+            }
+
+            assertFalse(store.contains("cmd-0"))
+            assertTrue(store.contains("cmd-2999"))
         }
-
-        assertFalse(store.contains("cmd-0"))
-        assertTrue(store.contains("cmd-2999"))
     }
 
     private fun newExecutor(
@@ -544,9 +546,9 @@ private class AlwaysTrustedPeerStore : PeerTrustStore {
 private class SharedBackingCommandIdStore(
     private val ids: MutableSet<String>,
 ) : CommandIdStore {
-    override fun contains(commandId: String): Boolean = ids.contains(commandId)
+    override suspend fun contains(commandId: String): Boolean = ids.contains(commandId)
 
-    override fun markProcessed(commandId: String) {
+    override suspend fun markProcessed(commandId: String) {
         ids.add(commandId)
     }
 }

--- a/app/src/test/java/com/example/orgclock/sync/RoomCommandIdStoreTest.kt
+++ b/app/src/test/java/com/example/orgclock/sync/RoomCommandIdStoreTest.kt
@@ -1,5 +1,6 @@
 package com.example.orgclock.sync
 
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -7,27 +8,29 @@ import org.junit.Test
 class RoomCommandIdStoreTest {
     @Test
     fun markProcessed_prunesByRetentionAndKeepsRecentRows() {
-        val dao = FakeProcessedCommandIdDao()
-        var now = 10_000L
-        val store = RoomCommandIdStore(
-            dao = dao,
-            nowEpochMs = { now },
-            retentionMs = 1_000L,
-            maxRows = 3L,
-        )
+        runBlocking {
+            val dao = FakeProcessedCommandIdDao()
+            var now = 10_000L
+            val store = RoomCommandIdStore(
+                dao = dao,
+                nowEpochMs = { now },
+                retentionMs = 1_000L,
+                maxRows = 3L,
+            )
 
-        store.markProcessed("cmd-1")
-        now += 2_000L
-        store.markProcessed("cmd-2")
-        now += 100L
-        store.markProcessed("cmd-3")
-        now += 100L
-        store.markProcessed("cmd-4")
+            store.markProcessed("cmd-1")
+            now += 2_000L
+            store.markProcessed("cmd-2")
+            now += 100L
+            store.markProcessed("cmd-3")
+            now += 100L
+            store.markProcessed("cmd-4")
 
-        assertFalse(store.contains("cmd-1"))
-        assertTrue(store.contains("cmd-2"))
-        assertTrue(store.contains("cmd-3"))
-        assertTrue(store.contains("cmd-4"))
+            assertFalse(store.contains("cmd-1"))
+            assertTrue(store.contains("cmd-2"))
+            assertTrue(store.contains("cmd-3"))
+            assertTrue(store.contains("cmd-4"))
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What changed
- make the Room-backed sync command/event stores safe to call from suspend contexts without touching the main thread
- add instrumentation coverage for the main-thread-safe sync store and clock recorder paths
- move sync startup work out of `Application.onCreate()` main-thread execution
- run clock start/stop/cancel route actions on the IO dispatcher
- update AndroidX test dependencies and align the Gradle wrapper with the AGP 8.7 toolchain used by this project for native Windows runs

## Why
Recent testing exposed two separate issues:
1. runtime start/stop/cancel paths could hit Room from the main thread, which surfaced as user-visible failures on device
2. emulator UI tests on native Windows were failing in Espresso because the older test stack still relied on `InputManager.getInstance()` on newer Android images

## Impact
- clock command flows should no longer fail due to main-thread Room access
- app startup avoids StrictMode disk-read violations from sync initialization
- emulator instrumentation tests now pass on native Windows with the project wrapper/tooling combination

## Validation
- `:app:connectedDebugAndroidTest` on native Windows against `Pixel_9a` AVD: 16/16 passed
- direct rerun of previously failing `OrgClockScreenTest` case after AndroidX test updates: passed
- `:app:assembleDebug :app:assembleDebugAndroidTest` in the Windows verification workspace: passed
- `:app:compileDebugKotlin` after the IO-dispatcher routing change: passed

## Root cause
- sync store access still reached Room on the main thread along some UI-driven command paths
- Espresso 3.6.1 was incompatible with the Android 16 / API 36 emulator image used during Windows-native instrumentation runs