### PR TITLE
[codex] Add secure QR desktop sync and installers

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,114 @@
+name: Release Desktop Installers
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing v-prefixed tag to publish"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release-${{ github.ref }}-${{ inputs.release_tag || '' }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact: desktop-windows
+          - os: ubuntu-latest
+            artifact: desktop-linux
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
+          [[ "$TAG" == v* ]] || { echo "::error::Release tag must start with v"; exit 1; }
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Build installers
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x ./gradlew
+          ./gradlew --stacktrace packageDesktopCurrentOs -Pdesktop.version="${{ steps.release.outputs.version }}"
+
+      - name: Collect Linux installers
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          find desktopApp/build/compose/binaries/main -type f -name '*.deb' -exec cp {} release-assets/ \;
+          tar -C desktopApp/build/compose/binaries/main/app -czf release-assets/org-clock-desktop-${{ steps.release.outputs.version }}-linux-portable.tar.gz .
+          test -n "$(find release-assets -type f -print -quit)"
+          (cd release-assets && sha256sum * > SHA256SUMS-linux.txt)
+
+      - name: Collect Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force release-assets | Out-Null
+          Get-ChildItem desktopApp/build/compose/binaries/main -Recurse -Filter *.msi | Copy-Item -Destination release-assets
+          if (-not (Get-ChildItem release-assets -Filter *.msi)) { throw "MSI installer was not generated" }
+          Get-ChildItem release-assets -File | ForEach-Object {
+            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+            "$hash  $($_.Name)" | Add-Content release-assets/SHA256SUMS-windows.txt
+          }
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: release-assets/*
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: release
+        run: echo "tag=${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Download installers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          generate_release_notes: true
+          files: release-assets/*
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Org Clock
 
+## Desktop版をインストール
+
+[Latest ReleaseからWindows/Linux版をダウンロード](https://github.com/shgnaka/LIFE_LOrG_Clock/releases/latest)
+
+- Windows: `.msi`
+- Linux: `.deb` またはportable `.tar.gz`
+- 詳細: [Desktop版のインストール手順](docs/desktop-install.md)
+- QR同期の安全性: [QRペアリングのセキュリティ](docs/sync-qr-security.md)
+
+
 この README は、外部向け README へ整理し直すための入口ページです。
 
 現在の開発・内部向けの全体概要は [docs/project-overview.md](docs/project-overview.md) に移しました。

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.documentfile:documentfile:1.0.1")
     implementation("androidx.work:work-runtime-ktx:2.10.0")
+    implementation("com.google.android.gms:play-services-code-scanner:16.1.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.google.mlkit.vision.DEPENDENCIES"
+            android:value="barcode_ui" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/orgclock/di/AppGraph.kt
+++ b/app/src/main/java/com/example/orgclock/di/AppGraph.kt
@@ -29,6 +29,7 @@ import com.example.orgclock.sync.ClockEventStoreSnapshot
 import com.example.orgclock.sync.ClockCommandKind
 import com.example.orgclock.sync.PeerRegistrationRequest
 import com.example.orgclock.sync.RoomClockEventStore
+import com.example.orgclock.sync.RepositoryRemoteClockEventApplier
 import com.example.orgclock.sync.DefaultClockCommandExecutor
 import com.example.orgclock.sync.AndroidEventSyncRuntime
 import com.example.orgclock.sync.AndroidEventSyncRuntimeEntryPoint
@@ -145,6 +146,7 @@ class DefaultAppGraph(
             appContext.getSharedPreferences(NotificationPrefs.PREFS_NAME, Context.MODE_PRIVATE),
         )
     }
+    private val peerTrustStore by lazy { SharedPreferencesPeerTrustStore(prefs) }
     private val peerSyncCheckpointStore by lazy {
         SharedPreferencesPeerSyncCheckpointStore(prefs)
     }
@@ -154,12 +156,23 @@ class DefaultAppGraph(
     private val androidEventSyncRuntime: AndroidEventSyncRuntime by lazy {
         AndroidEventSyncRuntime(
             clockEventStore = clockEventStore,
-            peerTrustStore = SharedPreferencesPeerTrustStore(prefs),
+            peerTrustStore = peerTrustStore,
             peerSyncCheckpointStore = peerSyncCheckpointStore,
             quarantineStore = clockEventSyncQuarantineStore,
             deviceIdProvider = deviceIdProvider,
             snapshotPublisher = { clockEventSyncSnapshotFlow.value = it },
-            transportProvider = AndroidEventSyncTransportProvider { null },
+            remoteEventApplier = RepositoryRemoteClockEventApplier(
+                repository = repository,
+                clockService = ClockService(repository, fileOperationCoordinator = fileOperationCoordinator),
+                timeZoneProvider = clockEnvironment::currentTimeZone,
+            ),
+            transportProvider = AndroidEventSyncTransportProvider { peerId ->
+                peerTrustStore.getTrustRecord(peerId)?.let { record ->
+                    record.endpoint?.let { endpoint ->
+                        AndroidLanSyncTransport(endpoint, record.publicKeyBase64)
+                    }
+                }
+            },
         )
     }
     private val clockEventRecorder by lazy {
@@ -204,7 +217,7 @@ class DefaultAppGraph(
             commandExecutor = commandExecutor,
             deviceIdProvider = deviceIdProvider,
             runtimePrefs = runtimePrefs,
-            peerTrustStore = SharedPreferencesPeerTrustStore(prefs),
+            peerTrustStore = peerTrustStore,
             clockEventStoreProvider = { clockEventStore },
             peerSyncCheckpointStore = peerSyncCheckpointStore,
             runtimeManager = runtimeManager,

--- a/app/src/main/java/com/example/orgclock/di/AppGraph.kt
+++ b/app/src/main/java/com/example/orgclock/di/AppGraph.kt
@@ -34,6 +34,7 @@ import com.example.orgclock.sync.DefaultClockCommandExecutor
 import com.example.orgclock.sync.AndroidEventSyncRuntime
 import com.example.orgclock.sync.AndroidEventSyncRuntimeEntryPoint
 import com.example.orgclock.sync.AndroidEventSyncTransportProvider
+import com.example.orgclock.sync.AndroidLanSyncTransport
 import com.example.orgclock.sync.LocalClockOperationPublisher
 import com.example.orgclock.sync.RuntimeSyncIntegrationFeatureFlag
 import com.example.orgclock.sync.RoomCommandIdStore

--- a/app/src/main/java/com/example/orgclock/sync/AndroidEventSyncRuntime.kt
+++ b/app/src/main/java/com/example/orgclock/sync/AndroidEventSyncRuntime.kt
@@ -36,6 +36,7 @@ class AndroidEventSyncRuntime(
     private val quarantineStore: ClockEventSyncQuarantineStore = NoOpClockEventSyncQuarantineStore,
     private val deviceIdProvider: DeviceIdProvider,
     private val snapshotPublisher: (ClockEventStoreSnapshot) -> Unit = {},
+    private val remoteEventApplier: RemoteClockEventApplier = RemoteClockEventApplier { Result.success(Unit) },
     private val transportProvider: AndroidEventSyncTransportProvider = AndroidEventSyncTransportProvider { null },
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
@@ -127,8 +128,13 @@ class AndroidEventSyncRuntime(
         transport: ClockEventSyncTransport,
     ) {
         val checkpoint = peerSyncCheckpointStore.get(peer.peerId)
-        val pending = clockEventStore.listSince(checkpoint?.lastSentCursor, DEFAULT_CLOCK_EVENT_TRANSPORT_BATCH_LIMIT)
-        if (pending.isEmpty()) return
+        val scanned = clockEventStore.listSince(checkpoint?.lastSentCursor, DEFAULT_CLOCK_EVENT_TRANSPORT_BATCH_LIMIT)
+        if (scanned.isEmpty()) return
+        val pending = scanned.filter { it.event.deviceId == localPeerId }
+        if (pending.isEmpty()) {
+            peerSyncCheckpointStore.markSent(peer.peerId, scanned.last().cursor, Clock.System.now().toEpochMilliseconds())
+            return
+        }
         val response = transport.push(
             ClockEventPushRequest(
                 sourcePeerId = localPeerId,
@@ -145,8 +151,7 @@ class AndroidEventSyncRuntime(
             )
             throw IllegalStateException("push rejected for ${peer.peerId}: $reason")
         }
-        val acceptedCursor = response.acceptedCursor ?: pending.last().cursor
-        peerSyncCheckpointStore.markSent(peer.peerId, acceptedCursor, Clock.System.now().toEpochMilliseconds())
+        peerSyncCheckpointStore.markSent(peer.peerId, scanned.last().cursor, Clock.System.now().toEpochMilliseconds())
     }
 
     private suspend fun fetchRemoteEvents(
@@ -188,6 +193,8 @@ class AndroidEventSyncRuntime(
             return false
         }
         val appended = response.events.mapNotNull { stored ->
+            if (clockEventStore.contains(stored.event.eventId)) return@mapNotNull null
+            remoteEventApplier.apply(stored.event).getOrThrow()
             when (clockEventStore.append(stored.event)) {
                 is AppendClockEventResult.Appended -> stored
                 is AppendClockEventResult.Duplicate -> null

--- a/app/src/main/java/com/example/orgclock/sync/AndroidLanSyncTransport.kt
+++ b/app/src/main/java/com/example/orgclock/sync/AndroidLanSyncTransport.kt
@@ -1,0 +1,140 @@
+package com.example.orgclock.sync
+
+import java.net.URI
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class AndroidLanSyncTransport(
+    endpoint: String,
+    encodedCredential: String,
+    private val connectTimeoutMs: Int = 5_000,
+    private val readTimeoutMs: Int = 10_000,
+) : ClockEventSyncTransport {
+    private val endpoint = endpoint.trimEnd('/')
+    private val credential = SyncTransportCredentialCodec.decode(encodedCredential).getOrThrow()
+    private val sslContext = pinnedSslContext(credential.certificateSha256)
+
+    override suspend fun fetch(request: ClockEventFetchRequest): ClockEventFetchResponse =
+        ClockEventTransportJsonCodec.decodeFetchResponse(post("/v1/events/fetch", ClockEventTransportJsonCodec.encodeFetchRequest(request)))
+
+    override suspend fun push(request: ClockEventPushRequest): ClockEventPushResponse =
+        ClockEventTransportJsonCodec.decodePushResponse(post("/v1/events/push", ClockEventTransportJsonCodec.encodePushRequest(request)))
+
+    override suspend fun acknowledge(ack: ClockEventTransportAck): ClockEventTransportAckResult =
+        ClockEventTransportJsonCodec.decodeAckResult(post("/v1/events/ack", ClockEventTransportJsonCodec.encodeAck(ack)))
+
+    suspend fun probe(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val connection = (URI.create(endpoint + "/v1/health").toURL().openConnection() as HttpsURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = connectTimeoutMs
+                readTimeout = readTimeoutMs
+                sslSocketFactory = sslContext.socketFactory
+                hostnameVerifier = HostnameVerifier { _, session ->
+                    runCatching {
+                        secureFingerprintEquals(session.peerCertificates.first() as X509Certificate, credential.certificateSha256)
+                    }.getOrDefault(false)
+                }
+            }
+            try {
+                check(connection.responseCode in 200..299) { "health status=${connection.responseCode}" }
+            } finally {
+                connection.disconnect()
+            }
+        }
+    }
+
+    private suspend fun post(path: String, body: String): String = withContext(Dispatchers.IO) {
+        val connection = (URI.create(endpoint + path).toURL().openConnection() as HttpsURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = connectTimeoutMs
+            readTimeout = readTimeoutMs
+            doOutput = true
+            sslSocketFactory = sslContext.socketFactory
+            hostnameVerifier = HostnameVerifier { _, session ->
+                runCatching {
+                    secureFingerprintEquals(session.peerCertificates.first() as X509Certificate, credential.certificateSha256)
+                }.getOrDefault(false)
+            }
+            setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            setRequestProperty(PAIRING_HEADER, credential.pairingSecret)
+        }
+        try {
+            connection.outputStream.use { it.write(body.encodeToByteArray()) }
+            val status = connection.responseCode
+            val response = (if (status in 200..299) connection.inputStream else connection.errorStream)
+                ?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }.orEmpty()
+            check(status in 200..299) { "sync https status=$status: ${response.take(300)}" }
+            response
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    companion object {
+        const val PAIRING_HEADER = "X-OrgClock-Pairing-Key"
+    }
+}
+
+private fun pinnedSslContext(expectedFingerprint: String): SSLContext {
+    val trustManager = object : X509TrustManager {
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+            require(chain.isNotEmpty()) { "Server certificate is missing." }
+            require(secureFingerprintEquals(chain.first(), expectedFingerprint)) {
+                "Server certificate fingerprint mismatch. Scan the desktop QR code again."
+            }
+        }
+    }
+    return SSLContext.getInstance("TLS").apply { init(null, arrayOf(trustManager), SecureRandom()) }
+}
+
+private fun secureFingerprintEquals(certificate: X509Certificate, expected: String): Boolean {
+    val actual = MessageDigest.getInstance("SHA-256").digest(certificate.encoded)
+        .joinToString("") { "%02x".format(it) }
+    return MessageDigest.isEqual(actual.encodeToByteArray(), expected.lowercase().encodeToByteArray())
+}
+
+suspend fun exchangeDesktopPairingInvitation(
+    endpoint: String,
+    encodedInvitation: String,
+    localDeviceId: String,
+): Result<String> = withContext(Dispatchers.IO) {
+    runCatching {
+        val invitation = SyncPairingInvitationCodec.decode(encodedInvitation).getOrThrow()
+        require(invitation.expiresAtEpochMs > System.currentTimeMillis()) { "Pairing QR code expired. Refresh it on desktop." }
+        val sslContext = pinnedSslContext(invitation.certificateSha256)
+        val connection = (URI.create(endpoint.trimEnd('/') + "/v1/pair").toURL().openConnection() as HttpsURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = 5_000
+            readTimeout = 10_000
+            doOutput = true
+            sslSocketFactory = sslContext.socketFactory
+            hostnameVerifier = HostnameVerifier { _, session ->
+                runCatching { secureFingerprintEquals(session.peerCertificates.first() as X509Certificate, invitation.certificateSha256) }.getOrDefault(false)
+            }
+            setRequestProperty("Content-Type", "application/json; charset=utf-8")
+        }
+        try {
+            val body = SyncPairingExchangeJsonCodec.encodeRequest(
+                SyncPairingExchangeRequest(invitation.token, localDeviceId, "Android $localDeviceId"),
+            )
+            connection.outputStream.use { it.write(body.encodeToByteArray()) }
+            val status = connection.responseCode
+            val response = (if (status in 200..299) connection.inputStream else connection.errorStream)
+                ?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }.orEmpty()
+            check(status in 200..299) { "pairing https status=$status: ${response.take(300)}" }
+            SyncPairingExchangeJsonCodec.decodeResponse(response).encodedTransportCredential
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/app/src/main/java/com/example/orgclock/sync/SyncIntegrationService.kt
+++ b/app/src/main/java/com/example/orgclock/sync/SyncIntegrationService.kt
@@ -315,38 +315,37 @@ class SyncIntegrationService(
             reachable = probe.reachable,
             lastCheckedAtEpochMs = probe.checkedAtEpochMs,
         )
-        if (probe.reachable) {
-            peerTrustStore.trust(normalized)
-        }
+        if (probe.reachable) peerTrustStore.trust(normalized)
         refreshStateSnapshot()
         return probe
     }
 
     suspend fun pairTrustedPeer(request: PeerRegistrationRequest): PeerProbeResult {
         val normalized = request.peerId.trim()
-        if (normalized.isBlank()) {
-            return PeerProbeResult(
-                peerId = normalized,
-                reachable = false,
-                checkedAtEpochMs = System.currentTimeMillis(),
-                reason = "peer id is empty",
-            )
+        val endpoint = request.endpoint?.trim().orEmpty()
+        if (normalized.isBlank() || endpoint.isBlank()) {
+            return PeerProbeResult(normalized, false, System.currentTimeMillis(), "peer endpoint is empty")
         }
-        if (request.publicKeyBase64.isBlank()) {
-            return PeerProbeResult(
-                peerId = normalized,
-                reachable = false,
-                checkedAtEpochMs = System.currentTimeMillis(),
-                reason = "public key is empty",
-            )
+        val invitation = SyncPairingInvitationCodec.decode(request.publicKeyBase64).getOrElse { error ->
+            return PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "invalid pairing invitation")
         }
-        peerTrustStore.trust(request.toPeerTrustRecord())
-        val probe = peerHealthChecker.probe(normalized)
-        updatePeerState(
-            peerId = normalized,
-            reachable = probe.reachable,
-            lastCheckedAtEpochMs = probe.checkedAtEpochMs,
+        if (invitation.expiresAtEpochMs <= System.currentTimeMillis()) {
+            return PeerProbeResult(normalized, false, System.currentTimeMillis(), "pairing QR code expired")
+        }
+        val durableCredential = exchangeDesktopPairingInvitation(
+            endpoint = endpoint,
+            encodedInvitation = request.publicKeyBase64,
+            localDeviceId = deviceIdProvider.getOrCreate(),
+        ).getOrElse { error ->
+            return PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "pairing failed")
+        }
+        val verifiedRequest = request.copy(publicKeyBase64 = durableCredential)
+        val probe = AndroidLanSyncTransport(endpoint, durableCredential).probe().fold(
+            onSuccess = { PeerProbeResult(normalized, true, System.currentTimeMillis()) },
+            onFailure = { error -> PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "probe failed") },
         )
+        if (probe.reachable) peerTrustStore.trust(verifiedRequest.toPeerTrustRecord())
+        updatePeerState(normalized, probe.reachable, probe.checkedAtEpochMs)
         refreshStateSnapshot()
         return probe
     }
@@ -361,12 +360,16 @@ class SyncIntegrationService(
                 reason = "peer id is empty",
             )
         }
-        val probe = peerHealthChecker.probe(normalized)
-        updatePeerState(
-            peerId = normalized,
-            reachable = probe.reachable,
-            lastCheckedAtEpochMs = probe.checkedAtEpochMs,
-        )
+        val record = peerTrustStore.getTrustRecord(normalized)
+        val probe = if (record?.endpoint?.startsWith("https://") == true && SyncTransportCredentialCodec.decode(record.publicKeyBase64).isSuccess) {
+            AndroidLanSyncTransport(record.endpoint, record.publicKeyBase64).probe().fold(
+                onSuccess = { PeerProbeResult(normalized, true, System.currentTimeMillis()) },
+                onFailure = { error -> PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "probe failed") },
+            )
+        } else {
+            peerHealthChecker.probe(normalized)
+        }
+        updatePeerState(peerId = normalized, reachable = probe.reachable, lastCheckedAtEpochMs = probe.checkedAtEpochMs)
         refreshStateSnapshot()
         return probe
     }

--- a/app/src/main/java/com/example/orgclock/sync/SyncIntegrationService.kt
+++ b/app/src/main/java/com/example/orgclock/sync/SyncIntegrationService.kt
@@ -361,8 +361,9 @@ class SyncIntegrationService(
             )
         }
         val record = peerTrustStore.getTrustRecord(normalized)
-        val probe = if (record?.endpoint?.startsWith("https://") == true && SyncTransportCredentialCodec.decode(record.publicKeyBase64).isSuccess) {
-            AndroidLanSyncTransport(record.endpoint, record.publicKeyBase64).probe().fold(
+        val endpoint = record?.endpoint
+        val probe = if (endpoint?.startsWith("https://") == true && SyncTransportCredentialCodec.decode(record.publicKeyBase64).isSuccess) {
+            AndroidLanSyncTransport(endpoint, record.publicKeyBase64).probe().fold(
                 onSuccess = { PeerProbeResult(normalized, true, System.currentTimeMillis()) },
                 onFailure = { error -> PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "probe failed") },
             )

--- a/app/src/main/java/com/example/orgclock/sync/SyncIntegrationService.kt
+++ b/app/src/main/java/com/example/orgclock/sync/SyncIntegrationService.kt
@@ -21,6 +21,11 @@ class SyncIntegrationService(
     private val peerSyncCheckpointStore: PeerSyncCheckpointStore? = null,
     private val peerHealthChecker: PeerHealthChecker = HttpPeerHealthChecker(),
     private val runtimeManager: SyncRuntimeManager? = null,
+    private val pairingInvitationExchange: suspend (String, String, String) -> Result<String> =
+        ::exchangeDesktopPairingInvitation,
+    private val securePeerProbe: suspend (String, String) -> Result<Unit> = { endpoint, credential ->
+        AndroidLanSyncTransport(endpoint, credential).probe()
+    },
 ) {
     private val peerStates = linkedMapOf<String, SyncPeerState>()
     private val recoveryService = ClockEventRecoveryService()
@@ -332,19 +337,19 @@ class SyncIntegrationService(
         if (invitation.expiresAtEpochMs <= System.currentTimeMillis()) {
             return PeerProbeResult(normalized, false, System.currentTimeMillis(), "pairing QR code expired")
         }
-        val durableCredential = exchangeDesktopPairingInvitation(
-            endpoint = endpoint,
-            encodedInvitation = request.publicKeyBase64,
-            localDeviceId = deviceIdProvider.getOrCreate(),
+        val durableCredential = pairingInvitationExchange(
+            endpoint,
+            request.publicKeyBase64,
+            deviceIdProvider.getOrCreate(),
         ).getOrElse { error ->
             return PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "pairing failed")
         }
         val verifiedRequest = request.copy(publicKeyBase64 = durableCredential)
-        val probe = AndroidLanSyncTransport(endpoint, durableCredential).probe().fold(
+        peerTrustStore.trust(verifiedRequest.toPeerTrustRecord())
+        val probe = securePeerProbe(endpoint, durableCredential).fold(
             onSuccess = { PeerProbeResult(normalized, true, System.currentTimeMillis()) },
             onFailure = { error -> PeerProbeResult(normalized, false, System.currentTimeMillis(), error.message ?: "probe failed") },
         )
-        if (probe.reachable) peerTrustStore.trust(verifiedRequest.toPeerTrustRecord())
         updatePeerState(normalized, probe.reachable, probe.checkedAtEpochMs)
         refreshStateSnapshot()
         return probe

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockRoute.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockRoute.kt
@@ -38,9 +38,9 @@ import com.example.orgclock.ui.state.OrgClockUiAction
 import com.example.orgclock.ui.state.OrgClockUiState
 import com.example.orgclock.ui.state.Screen
 import com.example.orgclock.ui.viewmodel.OrgClockViewModel
-import com.google.android.gms.mlkit.vision.codescanner.GmsBarcodeScannerOptions
-import com.google.android.gms.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockRoute.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockRoute.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModel
@@ -37,6 +38,9 @@ import com.example.orgclock.ui.state.OrgClockUiAction
 import com.example.orgclock.ui.state.OrgClockUiState
 import com.example.orgclock.ui.state.Screen
 import com.example.orgclock.ui.viewmodel.OrgClockViewModel
+import com.google.android.gms.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.android.gms.mlkit.vision.codescanner.GmsBarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -125,6 +129,14 @@ fun OrgClockRoute(
     val viewModel: OrgClockViewModel = viewModel(factory = factory)
     val state by viewModel.uiState.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+    val pairingScanner = remember(context) {
+        val options = GmsBarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .enableAutoZoom()
+            .build()
+        GmsBarcodeScanning.getClient(context, options)
+    }
 
     val rootPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
         if (uri != null) {
@@ -207,6 +219,15 @@ fun OrgClockRoute(
         zoneIdProvider = dependencies.zoneIdProvider,
         nowProvider = dependencies.nowProvider,
         onPickRoot = { rootPicker.launch(null) },
+        onScanPairingCode = {
+            pairingScanner.startScan()
+                .addOnSuccessListener { barcode ->
+                    barcode.rawValue?.let { viewModel.onAction(OrgClockUiAction.SyncApplyPairingCode(it)) }
+                }
+                .addOnFailureListener { _ ->
+                    viewModel.onAction(OrgClockUiAction.SyncApplyPairingCode("scan-error:"))
+                }
+        },
         onAction = viewModel::onAction,
     )
 }

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
@@ -174,8 +174,8 @@ fun OrgClockScreen(
     zoneIdProvider: () -> ZoneId,
     nowProvider: () -> ZonedDateTime,
     onPickRoot: () -> Unit,
-    onScanPairingCode: () -> Unit,
     onAction: (OrgClockUiAction) -> Unit,
+    onScanPairingCode: () -> Unit = {},
 ) {
     Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         when (state.screen) {

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
@@ -174,6 +174,7 @@ fun OrgClockScreen(
     zoneIdProvider: () -> ZoneId,
     nowProvider: () -> ZonedDateTime,
     onPickRoot: () -> Unit,
+    onScanPairingCode: () -> Unit,
     onAction: (OrgClockUiAction) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
@@ -313,6 +314,7 @@ fun OrgClockScreen(
                 onSyncUpdatePeerDisplayName = { onAction(OrgClockUiAction.SyncUpdatePeerDisplayName(it)) },
                 onSyncUpdatePeerPublicKey = { onAction(OrgClockUiAction.SyncUpdatePeerPublicKey(it)) },
                 onSyncSetPeerViewerMode = { onAction(OrgClockUiAction.SyncSetPeerViewerMode(it)) },
+                onScanPairingCode = onScanPairingCode,
                 onSyncAddPeer = { onAction(OrgClockUiAction.SyncAddPeer) },
                 onSyncRevokePeer = { onAction(OrgClockUiAction.SyncRevokePeer(it)) },
                 onSyncProbePeer = { onAction(OrgClockUiAction.SyncProbePeer(it)) },
@@ -1059,6 +1061,7 @@ private fun SettingsScreen(
     onSyncUpdatePeerDisplayName: (String) -> Unit,
     onSyncUpdatePeerPublicKey: (String) -> Unit,
     onSyncSetPeerViewerMode: (Boolean) -> Unit,
+    onScanPairingCode: () -> Unit,
     onSyncAddPeer: () -> Unit,
     onSyncRevokePeer: (String) -> Unit,
     onSyncProbePeer: (String) -> Unit,
@@ -1467,6 +1470,11 @@ private fun SettingsScreen(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(stringResource(R.string.sync_peer_viewer_role_label))
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = onScanPairingCode, enabled = !syncPeerBusy) {
+                            Text("Scan pairing QR")
+                        }
                     }
                     Button(
                         onClick = onSyncAddPeer,

--- a/app/src/test/java/com/example/orgclock/domain/ClockServiceEventAppendTest.kt
+++ b/app/src/test/java/com/example/orgclock/domain/ClockServiceEventAppendTest.kt
@@ -34,7 +34,7 @@ class ClockServiceEventAppendTest {
 
         assertTrue(result.isSuccess)
         assertEquals(listOf(ClockEventType.Started), recorder.events.map { it.type })
-        assertEquals("f1", recorder.events.single().fileName)
+        assertEquals("2026-03-18.org", recorder.events.single().fileName)
     }
 
     @Test

--- a/app/src/test/java/com/example/orgclock/sync/SyncIntegrationServicePairingTest.kt
+++ b/app/src/test/java/com/example/orgclock/sync/SyncIntegrationServicePairingTest.kt
@@ -19,15 +19,8 @@ class SyncIntegrationServicePairingTest {
             },
             runtimePrefs = TestSyncRuntimePrefs(),
             peerTrustStore = store,
-            peerHealthChecker = object : PeerHealthChecker {
-                override suspend fun probe(peerId: String): PeerProbeResult {
-                    return PeerProbeResult(
-                        peerId = peerId,
-                        reachable = true,
-                        checkedAtEpochMs = 1234L,
-                    )
-                }
-            },
+            pairingInvitationExchange = { _, _, _ -> Result.success("credential-a") },
+            securePeerProbe = { _, _ -> Result.success(Unit) },
         )
 
         val result = service.pairTrustedPeer(
@@ -35,8 +28,9 @@ class SyncIntegrationServicePairingTest {
                 peerId = "peer-a",
                 deviceId = "device-a",
                 displayName = "Desktop Host",
-                publicKeyBase64 = "pk-a",
+                publicKeyBase64 = validInvitation(),
                 role = PeerTrustRole.Viewer,
+                endpoint = "https://desktop.local:8787",
                 requestedAt = Instant.parse("2026-03-10T09:00:00Z"),
             ),
         )
@@ -46,7 +40,7 @@ class SyncIntegrationServicePairingTest {
         val record = store.getTrustRecord("peer-a")
         assertEquals("Desktop Host", record?.displayName)
         assertEquals(PeerTrustRole.Viewer, record?.role)
-        assertEquals("pk-a", record?.publicKeyBase64)
+        assertEquals("credential-a", record?.publicKeyBase64)
         assertEquals("peer-a", service.snapshot.value.trustedPeers.single())
         val peerState = service.snapshot.value.peerStates.single()
         assertEquals("Desktop Host", peerState.displayName)
@@ -67,16 +61,8 @@ class SyncIntegrationServicePairingTest {
             },
             runtimePrefs = TestSyncRuntimePrefs(),
             peerTrustStore = store,
-            peerHealthChecker = object : PeerHealthChecker {
-                override suspend fun probe(peerId: String): PeerProbeResult {
-                    return PeerProbeResult(
-                        peerId = peerId,
-                        reachable = false,
-                        checkedAtEpochMs = 1234L,
-                        reason = "unreachable",
-                    )
-                }
-            },
+            pairingInvitationExchange = { _, _, _ -> Result.success("credential-a") },
+            securePeerProbe = { _, _ -> Result.failure(IllegalStateException("unreachable")) },
         )
 
         val result = service.pairTrustedPeer(
@@ -84,8 +70,9 @@ class SyncIntegrationServicePairingTest {
                 peerId = "peer-a",
                 deviceId = "device-a",
                 displayName = "Desktop Host",
-                publicKeyBase64 = "pk-a",
+                publicKeyBase64 = validInvitation(),
                 role = PeerTrustRole.Viewer,
+                endpoint = "https://desktop.local:8787",
                 requestedAt = Instant.parse("2026-03-10T09:00:00Z"),
             ),
         )
@@ -95,6 +82,14 @@ class SyncIntegrationServicePairingTest {
         assertEquals(PeerTrustRole.Viewer, store.getTrustRecord("peer-a")?.role)
     }
 }
+
+private fun validInvitation(): String = SyncPairingInvitationCodec.encode(
+    SyncPairingInvitation(
+        token = "one-time-token",
+        certificateSha256 = "ab".repeat(32),
+        expiresAtEpochMs = System.currentTimeMillis() + 60_000,
+    ),
+)
 
 private class RecordingPeerTrustStore : PeerTrustStore {
     private val records = linkedMapOf<String, PeerTrustRecord>()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "2.0.21" apply false
     id("org.jetbrains.kotlin.multiplatform") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
 }
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,6 +1,11 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+val desktopPackageVersion = providers.gradleProperty("desktop.version")
+    .orElse(providers.environmentVariable("ORG_CLOCK_DESKTOP_VERSION"))
+    .getOrElse("1.0.0")
+    .removePrefix("v")
+
 val desktopTargetFormats = when {
     org.gradle.internal.os.OperatingSystem.current().isMacOsX -> arrayOf(TargetFormat.Dmg)
     org.gradle.internal.os.OperatingSystem.current().isWindows -> arrayOf(TargetFormat.Msi)
@@ -29,6 +34,8 @@ dependencies {
     implementation(compose.material3)
     implementation(project(":shared"))
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+    implementation("com.google.zxing:core:3.5.3")
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
@@ -41,7 +48,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(*desktopTargetFormats)
             packageName = "org-clock-desktop"
-            packageVersion = "1.0.0"
+            packageVersion = desktopPackageVersion
             description = "Cross-platform desktop MVP host for Org Clock."
             vendor = "shgnaka"
         }

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
@@ -10,6 +10,8 @@ import com.example.orgclock.presentation.RootReference
 import com.example.orgclock.sync.ClockEventStore
 import com.example.orgclock.sync.ClockEventStoreSnapshot
 import com.example.orgclock.sync.JdbcClockEventStore
+import com.example.orgclock.sync.RemoteClockEventApplier
+import com.example.orgclock.sync.RepositoryRemoteClockEventApplier
 import com.example.orgclock.sync.StoreBackedClockEventRecorder
 import com.example.orgclock.sync.SyncIntegrationSnapshot
 import com.example.orgclock.template.RootScheduleConfig
@@ -39,6 +41,7 @@ class DesktopAppGraph(
     private val settingsStore: DesktopSettingsStore = DesktopSettingsStore(),
     private val rootScheduleStore: DesktopRootScheduleStore = DesktopRootScheduleStore(),
     private val clockEnvironment: ClockEnvironment = DesktopSystemClockEnvironment,
+    private val syncIdentity: DesktopSyncIdentity = DesktopSyncIdentity(),
     private val repositoryFactory: (Path) -> ClockRepository = ::DesktopFileOrgRepository,
     private val coordinatorFactory: () -> FileOperationCoordinator = ::InMemoryFileOperationCoordinator,
     private val watchRootChanges: Boolean = true,
@@ -50,9 +53,12 @@ class DesktopAppGraph(
     private var peerSyncCheckpointStore: DesktopPeerSyncCheckpointStore? = null
     private var quarantineStore: DesktopClockEventSyncQuarantineStore? = null
     private var clockService: ClockService? = null
+    private var remoteClockEventApplier: RemoteClockEventApplier? = null
     private var openClockScanner: DesktopOpenClockScanner? = null
     private var rootWatcher: DesktopRootWatcher? = null
     private var scope: CoroutineScope? = null
+    private var lanSyncServer: DesktopLanSyncServer? = null
+    private val pairingManager = DesktopPairingManager()
     private val externalChangeFlow = MutableStateFlow<ExternalChangeNotice?>(null)
     private val clockEventSyncSnapshotFlow = MutableStateFlow(ClockEventStoreSnapshot(null, null, 0))
     private val desktopEventSyncRuntimeInstance: DesktopEventSyncRuntime by lazy {
@@ -62,11 +68,21 @@ class DesktopAppGraph(
             peerSyncCheckpointStoreProvider = { peerSyncCheckpointStore },
             quarantineStoreProvider = { quarantineStore },
             deviceIdProvider = {
-                currentRootPath?.let { "desktop-${it.toString().hashCode()}" } ?: "desktop-standalone"
+                currentRootPath?.let(syncIdentity::deviceId) ?: "desktop-standalone"
             },
             snapshotFlowProvider = { clockEventSyncSnapshotFlow },
             snapshotPublisher = { clockEventSyncSnapshotFlow.value = it },
-            transportProvider = DesktopEventSyncTransportProvider { null },
+            remoteEventApplier = RemoteClockEventApplier { event ->
+                remoteClockEventApplier?.apply(event)
+                    ?: Result.failure(IllegalStateException("org root is not open"))
+            },
+            transportProvider = DesktopEventSyncTransportProvider { peerId ->
+                peerTrustStore?.getTrustRecord(peerId)?.let { record ->
+                    record.endpoint?.let { endpoint ->
+                        DesktopLanSyncTransport(endpoint, record.publicKeyBase64)
+                    }
+                }
+            },
         )
     }
     private var externalChangeRevision = 0L
@@ -168,6 +184,18 @@ class DesktopAppGraph(
 
     fun currentRootReference(): RootReference? = currentRootPath?.let { RootReference(it.toString()) }
 
+    fun currentSyncPairingCode(): String? = currentRootPath?.let { root ->
+        val tls = syncIdentity.tlsIdentity(root)
+        syncIdentity.pairingCode(root, pairingManager.currentInvitation(tls.certificateSha256))
+    }
+
+    fun close() {
+        lanSyncServer?.close()
+        lanSyncServer = null
+        rootWatcher?.stop()
+        desktopEventSyncRuntimeInstance.stop()
+    }
+
     fun desktopEventSyncRuntime(): DesktopEventSyncRuntime {
         DesktopEventSyncRuntimeEntryPoint.runtime = desktopEventSyncRuntimeInstance
         return desktopEventSyncRuntimeInstance
@@ -184,12 +212,13 @@ class DesktopAppGraph(
         val trustStore = DesktopPeerTrustStore()
         val checkpointStore = DesktopPeerSyncCheckpointStore(desktopCheckpointStorePreferences(normalized))
         val quarantineStore = DesktopClockEventSyncQuarantineStore(desktopQuarantineStorePreferences(normalized))
+        val fileOperationCoordinator = coordinatorFactory()
         val clockService = ClockService(
             repository,
-            fileOperationCoordinator = coordinatorFactory(),
+            fileOperationCoordinator = fileOperationCoordinator,
             clockEventRecorder = StoreBackedClockEventRecorder(
                 store = eventStore,
-                deviceIdProvider = { "desktop-${normalized.toString().hashCode()}" },
+                deviceIdProvider = { syncIdentity.deviceId(normalized) },
                 snapshotPublisher = { clockEventSyncSnapshotFlow.value = it },
             ),
         )
@@ -200,7 +229,23 @@ class DesktopAppGraph(
         this.peerSyncCheckpointStore = checkpointStore
         this.quarantineStore = quarantineStore
         this.clockService = clockService
+        this.remoteClockEventApplier = RepositoryRemoteClockEventApplier(
+            repository = repository,
+            clockService = ClockService(repository, fileOperationCoordinator = fileOperationCoordinator),
+            timeZoneProvider = clockEnvironment::currentTimeZone,
+        )
         this.openClockScanner = DesktopOpenClockScanner(repository)
+        if (watchRootChanges) {
+            lanSyncServer?.close()
+            lanSyncServer = DesktopLanSyncServer(
+                localDeviceId = { syncIdentity.deviceId(normalized) },
+                eventStore = { this.clockEventStore },
+                trustStore = { this.peerTrustStore },
+                tlsIdentity = { syncIdentity.tlsIdentity(normalized) },
+                pairingManager = pairingManager,
+                remoteEventApplier = requireNotNull(remoteClockEventApplier),
+            ).also { it.start() }
+        }
         clockEventSyncSnapshotFlow.value = ClockEventStoreSnapshot(null, null, 0)
         desktopEventSyncRuntimeInstance.onRootOpened()
         rootWatcher?.stop()

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopEventSyncRuntime.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopEventSyncRuntime.kt
@@ -18,6 +18,7 @@ import com.example.orgclock.sync.DEFAULT_CLOCK_EVENT_TRANSPORT_BATCH_LIMIT
 import com.example.orgclock.sync.PeerSyncCheckpointStore
 import com.example.orgclock.sync.PeerTrustRecord
 import com.example.orgclock.sync.PeerTrustRole
+import com.example.orgclock.sync.RemoteClockEventApplier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -65,6 +66,7 @@ class DesktopEventSyncRuntime(
     private val deviceIdProvider: () -> String,
     private val snapshotFlowProvider: () -> StateFlow<ClockEventStoreSnapshot>? = { null },
     private val snapshotPublisher: (ClockEventStoreSnapshot) -> Unit = {},
+    private val remoteEventApplier: RemoteClockEventApplier = RemoteClockEventApplier { Result.success(Unit) },
     private val transportProvider: DesktopEventSyncTransportProvider = DesktopEventSyncTransportProvider { null },
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
@@ -199,8 +201,13 @@ class DesktopEventSyncRuntime(
         checkpointStore: PeerSyncCheckpointStore,
     ) {
         val checkpoint = checkpointStore.get(peer.peerId)
-        val pending = store.listSince(checkpoint?.lastSentCursor, DEFAULT_CLOCK_EVENT_TRANSPORT_BATCH_LIMIT)
-        if (pending.isEmpty()) return
+        val scanned = store.listSince(checkpoint?.lastSentCursor, DEFAULT_CLOCK_EVENT_TRANSPORT_BATCH_LIMIT)
+        if (scanned.isEmpty()) return
+        val pending = scanned.filter { it.event.deviceId == localPeerId }
+        if (pending.isEmpty()) {
+            checkpointStore.markSent(peer.peerId, scanned.last().cursor, Clock.System.now().toEpochMilliseconds())
+            return
+        }
         val response = transport.push(
             ClockEventPushRequest(
                 sourcePeerId = localPeerId,
@@ -219,8 +226,7 @@ class DesktopEventSyncRuntime(
             publishSnapshot(store, checkpointQuarantineStore(), reason)
             throw IllegalStateException("push rejected for ${peer.peerId}: $reason")
         }
-        val acceptedCursor = response.acceptedCursor ?: pending.last().cursor
-        checkpointStore.markSent(peer.peerId, acceptedCursor, Clock.System.now().toEpochMilliseconds())
+        checkpointStore.markSent(peer.peerId, scanned.last().cursor, Clock.System.now().toEpochMilliseconds())
     }
 
     private suspend fun fetchRemoteEvents(
@@ -266,6 +272,8 @@ class DesktopEventSyncRuntime(
             return false
         }
         val appended = response.events.mapNotNull { stored ->
+            if (store.contains(stored.event.eventId)) return@mapNotNull null
+            remoteEventApplier.apply(stored.event).getOrThrow()
             when (store.append(stored.event)) {
                 is AppendClockEventResult.Appended -> stored
                 is AppendClockEventResult.Duplicate -> null

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncServer.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncServer.kt
@@ -1,0 +1,125 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.sync.AppendClockEventResult
+import com.example.orgclock.sync.ClockEventFetchResponse
+import com.example.orgclock.sync.ClockEventPushResponse
+import com.example.orgclock.sync.ClockEventStore
+import com.example.orgclock.sync.ClockEventTransportAckResult
+import com.example.orgclock.sync.ClockEventTransportJsonCodec
+import com.example.orgclock.sync.PeerTrustRecord
+import com.example.orgclock.sync.RemoteClockEventApplier
+import com.example.orgclock.sync.SyncPairingExchangeJsonCodec
+import com.example.orgclock.sync.SyncPairingExchangeResponse
+import com.example.orgclock.sync.SyncTransportCredentialCodec
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpsConfigurator
+import com.sun.net.httpserver.HttpsServer
+import java.net.InetSocketAddress
+import java.security.MessageDigest
+import java.util.concurrent.Executors
+import kotlinx.coroutines.runBlocking
+
+class DesktopLanSyncServer(
+    private val port: Int = DesktopSyncIdentity.DEFAULT_PORT,
+    private val localDeviceId: () -> String,
+    private val eventStore: () -> ClockEventStore?,
+    private val trustStore: () -> PeerTrustStore?,
+    private val tlsIdentity: () -> DesktopTlsIdentity,
+    private val pairingManager: DesktopPairingManager,
+    private val remoteEventApplier: RemoteClockEventApplier,
+) : AutoCloseable {
+    private var server: HttpsServer? = null
+
+    fun start() {
+        if (server != null) return
+        server = HttpsServer.create(InetSocketAddress("0.0.0.0", port), 0).apply {
+            httpsConfigurator = HttpsConfigurator(tlsIdentity().sslContext)
+            executor = Executors.newFixedThreadPool(4) { Thread(it, "org-clock-lan-sync").apply { isDaemon = true } }
+            createContext("/v1/health") { exchange ->
+                if (exchange.requestMethod != "GET") exchange.respond(405, "method not allowed")
+                else exchange.respond(200, "ok", "text/plain; charset=utf-8")
+            }
+            createContext("/v1/pair") { exchange -> handlePost(exchange) { body ->
+                val request = SyncPairingExchangeJsonCodec.decodeRequest(body)
+                val credential = pairingManager.exchange(
+                    request,
+                    trustStore() ?: error("org root is not open"),
+                    tlsIdentity().certificateSha256,
+                )
+                SyncPairingExchangeJsonCodec.encodeResponse(SyncPairingExchangeResponse(credential))
+            } }
+            createContext("/v1/events/fetch") { exchange -> handleAuthorized(exchange) { body, peer ->
+                val request = ClockEventTransportJsonCodec.decodeFetchRequest(body)
+                requireSource(peer, request.sourcePeerId)
+                requireTarget(request.targetPeerId)
+                val scanned = runBlocking {
+                    (eventStore() ?: error("org root is not open")).listSince(request.sinceCursor, request.batchLimit * 4)
+                }
+                val events = scanned.filter { it.event.deviceId == localDeviceId() }.take(request.batchLimit)
+                ClockEventTransportJsonCodec.encodeFetchResponse(
+                    ClockEventFetchResponse(
+                        sourcePeerId = localDeviceId(),
+                        targetPeerId = request.sourcePeerId,
+                        events = events,
+                        hasMore = scanned.size == request.batchLimit * 4 || events.size == request.batchLimit,
+                    ),
+                )
+            } }
+            createContext("/v1/events/push") { exchange -> handleAuthorized(exchange) { body, peer ->
+                val request = ClockEventTransportJsonCodec.decodePushRequest(body)
+                requireSource(peer, request.sourcePeerId)
+                requireTarget(request.targetPeerId)
+                require(request.events.all { it.event.deviceId == peer.deviceId }) { "event device does not match paired device" }
+                val store = eventStore() ?: error("org root is not open")
+                val duplicates = mutableListOf<String>()
+                runBlocking {
+                    request.events.forEach { stored ->
+                        if (store.contains(stored.event.eventId)) {
+                            duplicates += stored.event.eventId
+                        } else {
+                            remoteEventApplier.apply(stored.event).getOrThrow()
+                            if (store.append(stored.event) is AppendClockEventResult.Duplicate) {
+                                duplicates += stored.event.eventId
+                            }
+                        }
+                    }
+                }
+                ClockEventTransportJsonCodec.encodePushResponse(
+                    ClockEventPushResponse(sourcePeerId = localDeviceId(), targetPeerId = request.sourcePeerId, acceptedCursor = request.events.lastOrNull()?.cursor, duplicateEventIds = duplicates),
+                )
+            } }
+            createContext("/v1/events/ack") { exchange -> handleAuthorized(exchange) { body, peer ->
+                val ack = ClockEventTransportJsonCodec.decodeAck(body)
+                requireSource(peer, ack.sourcePeerId)
+                requireTarget(ack.targetPeerId)
+                ClockEventTransportJsonCodec.encodeAckResult(ClockEventTransportAckResult.Accepted)
+            } }
+            start()
+        }
+    }
+
+    override fun close() { server?.stop(0); server = null }
+
+    private fun handlePost(exchange: HttpExchange, handler: (String) -> String) {
+        if (exchange.requestMethod != "POST") return exchange.respond(405, "method not allowed")
+        runCatching { handler(exchange.requestBody.bufferedReader(Charsets.UTF_8).use { it.readText() }) }
+            .onSuccess { exchange.respond(200, it) }.onFailure { exchange.respond(400, it.message ?: "invalid request") }
+    }
+
+    private fun handleAuthorized(exchange: HttpExchange, handler: (String, PeerTrustRecord) -> String) {
+        if (exchange.requestMethod != "POST") return exchange.respond(405, "method not allowed")
+        val supplied = exchange.requestHeaders.getFirst(DesktopLanSyncTransport.PAIRING_HEADER).orEmpty()
+        val peer = trustStore()?.listTrustRecords()?.firstOrNull { record ->
+            record.isActive && SyncTransportCredentialCodec.decode(record.publicKeyBase64).getOrNull()?.pairingSecret?.let { secureEquals(supplied, it) } == true
+        } ?: return exchange.respond(401, "invalid pairing credential")
+        runCatching { handler(exchange.requestBody.bufferedReader(Charsets.UTF_8).use { it.readText() }, peer) }
+            .onSuccess { exchange.respond(200, it) }.onFailure { exchange.respond(400, it.message ?: "invalid sync request") }
+    }
+
+    private fun requireSource(peer: PeerTrustRecord, sourcePeerId: String) = require(sourcePeerId == peer.deviceId) { "source peer mismatch" }
+    private fun requireTarget(targetPeerId: String?) = require(targetPeerId == localDeviceId()) { "target peer mismatch" }
+    private fun secureEquals(left: String, right: String) = MessageDigest.isEqual(left.encodeToByteArray(), right.encodeToByteArray())
+    private fun HttpExchange.respond(status: Int, body: String, type: String = "application/json; charset=utf-8") {
+        val bytes = body.encodeToByteArray(); responseHeaders.set("Content-Type", type); sendResponseHeaders(status, bytes.size.toLong()); responseBody.use { it.write(bytes) }
+    }
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncTransport.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncTransport.kt
@@ -1,0 +1,91 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.sync.ClockEventFetchRequest
+import com.example.orgclock.sync.ClockEventFetchResponse
+import com.example.orgclock.sync.ClockEventPushRequest
+import com.example.orgclock.sync.ClockEventPushResponse
+import com.example.orgclock.sync.ClockEventSyncTransport
+import com.example.orgclock.sync.ClockEventTransportAck
+import com.example.orgclock.sync.ClockEventTransportAckResult
+import com.example.orgclock.sync.ClockEventTransportJsonCodec
+import com.example.orgclock.sync.SyncTransportCredentialCodec
+import java.net.URI
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+class DesktopLanSyncTransport(
+    endpoint: String,
+    encodedCredential: String,
+    private val connectTimeoutMs: Int = 5_000,
+    private val readTimeoutMs: Int = 10_000,
+) : ClockEventSyncTransport {
+    private val endpoint = endpoint.trimEnd('/')
+    private val credential = SyncTransportCredentialCodec.decode(encodedCredential).getOrThrow()
+    private val sslContext = pinnedSslContext(credential.certificateSha256)
+
+    override suspend fun fetch(request: ClockEventFetchRequest): ClockEventFetchResponse =
+        ClockEventTransportJsonCodec.decodeFetchResponse(post("/v1/events/fetch", ClockEventTransportJsonCodec.encodeFetchRequest(request)))
+
+    override suspend fun push(request: ClockEventPushRequest): ClockEventPushResponse =
+        ClockEventTransportJsonCodec.decodePushResponse(post("/v1/events/push", ClockEventTransportJsonCodec.encodePushRequest(request)))
+
+    override suspend fun acknowledge(ack: ClockEventTransportAck): ClockEventTransportAckResult =
+        ClockEventTransportJsonCodec.decodeAckResult(post("/v1/events/ack", ClockEventTransportJsonCodec.encodeAck(ack)))
+
+    private fun post(path: String, body: String): String {
+        val connection = (URI.create(endpoint + path).toURL().openConnection() as HttpsURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = connectTimeoutMs
+            readTimeout = readTimeoutMs
+            doOutput = true
+            sslSocketFactory = sslContext.socketFactory
+            hostnameVerifier = javax.net.ssl.HostnameVerifier { host, session ->
+                PinnedHostnameVerifier(credential.certificateSha256).verify(host, session)
+            }
+            setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            setRequestProperty(PAIRING_HEADER, credential.pairingSecret)
+        }
+        try {
+            connection.outputStream.use { it.write(body.encodeToByteArray()) }
+            val status = connection.responseCode
+            val response = (if (status in 200..299) connection.inputStream else connection.errorStream)
+                ?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }.orEmpty()
+            check(status in 200..299) { "sync https status=$status: ${response.take(300)}" }
+            return response
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    companion object {
+        const val PAIRING_HEADER = "X-OrgClock-Pairing-Key"
+    }
+}
+
+private fun pinnedSslContext(expectedFingerprint: String): SSLContext {
+    val trustManager = object : X509TrustManager {
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+            require(chain.isNotEmpty()) { "Server certificate is missing." }
+            require(secureFingerprintEquals(chain.first(), expectedFingerprint)) { "Server certificate fingerprint mismatch." }
+        }
+    }
+    return SSLContext.getInstance("TLS").apply { init(null, arrayOf(trustManager), SecureRandom()) }
+}
+
+private class PinnedHostnameVerifier(private val expectedFingerprint: String) {
+    fun verify(host: String, session: javax.net.ssl.SSLSession): Boolean = runCatching {
+        val certificate = session.peerCertificates.first() as X509Certificate
+        secureFingerprintEquals(certificate, expectedFingerprint)
+    }.getOrDefault(false)
+}
+
+private fun secureFingerprintEquals(certificate: X509Certificate, expected: String): Boolean {
+    val actual = certificate.sha256Hex().encodeToByteArray()
+    return MessageDigest.isEqual(actual, expected.lowercase().encodeToByteArray())
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopPairingManager.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopPairingManager.kt
@@ -1,0 +1,55 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.sync.PeerTrustRecord
+import com.example.orgclock.sync.SyncPairingExchangeRequest
+import com.example.orgclock.sync.SyncPairingInvitation
+import com.example.orgclock.sync.SyncTransportCredential
+import com.example.orgclock.sync.SyncTransportCredentialCodec
+import java.security.SecureRandom
+import java.util.Base64
+import kotlinx.datetime.Clock
+
+class DesktopPairingManager(
+    private val nowEpochMs: () -> Long = System::currentTimeMillis,
+    private val tokenLifetimeMs: Long = 120_000L,
+) {
+    private val random = SecureRandom()
+    private var active: SyncPairingInvitation? = null
+
+    @Synchronized
+    fun currentInvitation(certificateSha256: String): SyncPairingInvitation {
+        val now = nowEpochMs()
+        val existing = active
+        if (existing != null && existing.expiresAtEpochMs > now && existing.certificateSha256 == certificateSha256) return existing
+        return SyncPairingInvitation(randomToken(), certificateSha256, now + tokenLifetimeMs).also { active = it }
+    }
+
+    @Synchronized
+    fun exchange(
+        request: SyncPairingExchangeRequest,
+        trustStore: PeerTrustStore,
+        certificateSha256: String,
+    ): String {
+        val invitation = active ?: error("pairing invitation is not active")
+        require(invitation.expiresAtEpochMs > nowEpochMs()) { "pairing invitation expired" }
+        require(invitation.token == request.invitationToken) { "invalid pairing invitation" }
+        require(request.deviceId.isNotBlank()) { "device id is empty" }
+        active = null
+        val credential = SyncTransportCredential(randomToken(), certificateSha256)
+        trustStore.trust(
+            PeerTrustRecord(
+                peerId = request.deviceId,
+                deviceId = request.deviceId,
+                displayName = request.displayName.trim().ifBlank { request.deviceId },
+                publicKeyBase64 = SyncTransportCredentialCodec.encode(credential),
+                registeredAt = Clock.System.now(),
+                lastSeenAt = Clock.System.now(),
+            ),
+        )
+        return SyncTransportCredentialCodec.encode(credential)
+    }
+
+    private fun randomToken(): String = ByteArray(32).also(random::nextBytes).let {
+        Base64.getUrlEncoder().withoutPadding().encodeToString(it)
+    }
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSyncIdentity.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSyncIdentity.kt
@@ -1,0 +1,44 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.sync.SyncPairingCode
+import com.example.orgclock.sync.SyncPairingCodeCodec
+import com.example.orgclock.sync.SyncPairingInvitation
+import com.example.orgclock.sync.SyncPairingInvitationCodec
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.nio.file.Path
+
+class DesktopSyncIdentity(
+    private val port: Int = DEFAULT_PORT,
+) {
+    fun pairingCode(rootPath: Path, invitation: SyncPairingInvitation): String? {
+        val host = findLanAddress() ?: return null
+        val authority = "$host:$port"
+        val credential = SyncPairingInvitationCodec.encode(invitation)
+        return SyncPairingCodeCodec.encode(
+            SyncPairingCode(
+                peerId = deviceId(rootPath),
+                deviceId = deviceId(rootPath),
+                displayName = System.getProperty("user.name")?.takeIf { it.isNotBlank() }?.let { "$it desktop" }
+                    ?: "Org Clock Desktop",
+                publicKeyBase64 = credential,
+                endpoint = "https://$authority",
+            ),
+        )
+    }
+
+    fun deviceId(rootPath: Path): String = "desktop-${rootPath.toString().hashCode()}"
+    fun tlsIdentity(rootPath: Path): DesktopTlsIdentity = DesktopTlsIdentity.loadOrCreate(rootPath)
+
+    private fun findLanAddress(): String? = NetworkInterface.getNetworkInterfaces().toList()
+        .asSequence()
+        .filter { it.isUp && !it.isLoopback && !it.isVirtual }
+        .flatMap { it.inetAddresses.toList().asSequence() }
+        .filterIsInstance<Inet4Address>()
+        .map { it.hostAddress }
+        .firstOrNull { !it.startsWith("169.254.") }
+
+    companion object {
+        const val DEFAULT_PORT = 8787
+    }
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopTlsIdentity.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopTlsIdentity.kt
@@ -1,0 +1,100 @@
+package com.example.orgclock.desktop
+
+import java.math.BigInteger
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.X509Certificate
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Date
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+
+class DesktopTlsIdentity private constructor(
+    val sslContext: SSLContext,
+    val certificateSha256: String,
+) {
+    companion object {
+        private const val KEY_ALIAS = "org-clock-lan-sync"
+        private const val STORE_FILE = "lan-sync.p12"
+        private val password = "org-clock-local-sync".toCharArray()
+
+        fun loadOrCreate(rootPath: Path): DesktopTlsIdentity {
+            ensureProvider()
+            val rootKey = MessageDigest.getInstance("SHA-256")
+                .digest(rootPath.toAbsolutePath().normalize().toString().encodeToByteArray())
+                .joinToString("") { "%02x".format(it) }
+                .take(24)
+            val directory = Path.of(System.getProperty("user.home"), ".orgclock", "tls", rootKey)
+            Files.createDirectories(directory)
+            setOwnerOnlyPermissions(directory, isDirectory = true)
+            val storePath = directory.resolve(STORE_FILE)
+            val keyStore = KeyStore.getInstance("PKCS12")
+            if (Files.exists(storePath)) {
+                Files.newInputStream(storePath).use { keyStore.load(it, password) }
+            } else {
+                keyStore.load(null, password)
+                val keyPair = KeyPairGenerator.getInstance("EC").apply { initialize(256) }.generateKeyPair()
+                val now = Instant.now()
+                val subject = X500Name("CN=Org Clock Desktop LAN Sync")
+                val certificateBuilder = JcaX509v3CertificateBuilder(
+                    subject,
+                    BigInteger(160, SecureRandom()),
+                    Date.from(now.minus(1, ChronoUnit.DAYS)),
+                    Date.from(now.plus(3650, ChronoUnit.DAYS)),
+                    subject,
+                    keyPair.public,
+                )
+                val signer = JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
+                val certificate = JcaX509CertificateConverter().setProvider("BC")
+                    .getCertificate(certificateBuilder.build(signer))
+                certificate.verify(keyPair.public)
+                keyStore.setKeyEntry(KEY_ALIAS, keyPair.private, password, arrayOf(certificate))
+                Files.newOutputStream(storePath).use { keyStore.store(it, password) }
+                setOwnerOnlyPermissions(storePath, isDirectory = false)
+            }
+            val certificate = keyStore.getCertificate(KEY_ALIAS) as X509Certificate
+            val keyManagers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+                init(keyStore, password)
+            }
+            val sslContext = SSLContext.getInstance("TLS").apply {
+                init(keyManagers.keyManagers, null, SecureRandom())
+            }
+            return DesktopTlsIdentity(sslContext, certificate.sha256Hex())
+        }
+
+        private fun ensureProvider() {
+            if (Security.getProvider("BC") == null) Security.addProvider(BouncyCastleProvider())
+        }
+
+        private fun setOwnerOnlyPermissions(path: Path, isDirectory: Boolean) {
+            runCatching {
+                val permissions = if (isDirectory) {
+                    setOf(
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_EXECUTE,
+                    )
+                } else {
+                    setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+                }
+                Files.setPosixFilePermissions(path, permissions)
+            }
+        }
+    }
+}
+
+internal fun X509Certificate.sha256Hex(): String = MessageDigest.getInstance("SHA-256")
+    .digest(encoded)
+    .joinToString("") { "%02x".format(it) }

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
@@ -5,6 +5,7 @@ package com.example.orgclock.desktop
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -69,6 +71,8 @@ import com.example.orgclock.ui.state.CreateHeadingDialogState
 import com.example.orgclock.ui.state.CreateHeadingMode
 import com.example.orgclock.ui.state.OrgClockUiAction
 import com.example.orgclock.ui.state.OrgClockUiState
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import kotlinx.datetime.TimeZone
@@ -108,7 +112,7 @@ private fun DesktopApp() {
     }
     DisposableEffect(runtime) {
         onDispose {
-            runtime.stop()
+            graph.close()
         }
     }
 
@@ -131,6 +135,7 @@ private fun DesktopApp() {
                 DesktopHostCard(
                     state = state,
                     syncState = syncState,
+                    syncPairingCode = graph.currentSyncPairingCode(),
                     onPickRoot = {
                         chooseRootDirectory(state.rootReference)?.let { root ->
                             store.onAction(OrgClockUiAction.PickRoot(root))
@@ -152,6 +157,7 @@ private fun DesktopApp() {
 private fun DesktopHostCard(
     state: OrgClockUiState,
     syncState: DesktopEventSyncRuntimeState,
+    syncPairingCode: String?,
     onPickRoot: () -> Unit,
     onAction: (OrgClockUiAction) -> Unit,
     onSyncNow: () -> Unit,
@@ -207,6 +213,7 @@ private fun DesktopHostCard(
                 Screen.Settings -> SettingsPane(
                     state = state,
                     syncState = syncState,
+                    syncPairingCode = syncPairingCode,
                     onChangeRoot = onPickRoot,
                     onBack = { onAction(OrgClockUiAction.BackFromSettings) },
                     onReloadFiles = { onAction(OrgClockUiAction.RefreshFiles) },
@@ -521,6 +528,7 @@ private fun HeadingRow(
 private fun SettingsPane(
     state: OrgClockUiState,
     syncState: DesktopEventSyncRuntimeState,
+    syncPairingCode: String?,
     onChangeRoot: () -> Unit,
     onBack: () -> Unit,
     onReloadFiles: () -> Unit,
@@ -544,6 +552,7 @@ private fun SettingsPane(
         )
         DesktopSyncSettingsCard(
             state = syncState,
+            pairingCode = syncPairingCode,
             onSyncNow = onSyncNow,
         )
         FileMonitoringSettingsCard(
@@ -905,6 +914,7 @@ private fun AboutDesktopSettingsCard() {
 @Composable
 private fun DesktopSyncSettingsCard(
     state: DesktopEventSyncRuntimeState,
+    pairingCode: String?,
     onSyncNow: () -> Unit,
 ) {
     val status = when {
@@ -942,6 +952,15 @@ private fun DesktopSyncSettingsCard(
             value = state.quarantinedEventCount.toString(),
         )
         SettingsFieldRow(label = "Peer count", value = peerSummary)
+        if (pairingCode != null) {
+            Text("Scan this QR code on another Org Clock device. It expires in 2 minutes and can be used only once.")
+            PairingQrCode(pairingCode)
+        } else {
+            SettingsMessageBlock(
+                text = "No LAN IPv4 address is available. Connect this desktop to the same network as the other device.",
+                tone = SettingsMessageTone.Warning,
+            )
+        }
         state.lastError?.takeIf { it.isNotBlank() }?.let { error ->
             SettingsMessageBlock(text = error, tone = SettingsMessageTone.Warning)
         }
@@ -1443,5 +1462,32 @@ private fun chooseRootDirectory(currentRoot: RootReference?): RootReference? {
         chooser.selectedFile?.toPath()?.toAbsolutePath()?.normalize()?.toString()?.let(::RootReference)
     } else {
         null
+    }
+}
+
+@Composable
+private fun PairingQrCode(value: String) {
+    val matrix = remember(value) {
+        QRCodeWriter().encode(value, BarcodeFormat.QR_CODE, 45, 45)
+    }
+    Canvas(
+        modifier = Modifier
+            .size(220.dp)
+            .background(Color.White)
+            .padding(10.dp),
+    ) {
+        val cellWidth = size.width / matrix.width
+        val cellHeight = size.height / matrix.height
+        for (x in 0 until matrix.width) {
+            for (y in 0 until matrix.height) {
+                if (matrix[x, y]) {
+                    drawRect(
+                        color = Color.Black,
+                        topLeft = androidx.compose.ui.geometry.Offset(x * cellWidth, y * cellHeight),
+                        size = androidx.compose.ui.geometry.Size(cellWidth, cellHeight),
+                    )
+                }
+            }
+        }
     }
 }

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopPairingManagerTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopPairingManagerTest.kt
@@ -1,0 +1,48 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.sync.SyncPairingExchangeRequest
+import com.example.orgclock.sync.SyncTransportCredentialCodec
+import java.util.UUID
+import java.util.prefs.Preferences
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DesktopPairingManagerTest {
+    @Test
+    fun invitationIsSingleUseAndCreatesPerDeviceCredential() {
+        var now = 1_000L
+        val manager = DesktopPairingManager(nowEpochMs = { now }, tokenLifetimeMs = 120_000L)
+        val fingerprint = "ab".repeat(32)
+        val invitation = manager.currentInvitation(fingerprint)
+        val prefs = Preferences.userRoot().node("orgclock-test/${UUID.randomUUID()}")
+        try {
+            val store = DesktopPeerTrustStore(prefs)
+            val encoded = manager.exchange(SyncPairingExchangeRequest(invitation.token, "phone-1", "Phone"), store, fingerprint)
+            assertNotNull(store.getTrustRecord("phone-1"))
+            assertTrue(SyncTransportCredentialCodec.decode(encoded).isSuccess)
+            assertFailsWith<IllegalStateException> {
+                manager.exchange(SyncPairingExchangeRequest(invitation.token, "phone-2", "Other"), store, fingerprint)
+            }
+        } finally {
+            prefs.removeNode()
+        }
+    }
+
+    @Test
+    fun expiredInvitationIsRejected() {
+        var now = 1_000L
+        val manager = DesktopPairingManager(nowEpochMs = { now }, tokenLifetimeMs = 10L)
+        val invitation = manager.currentInvitation("cd".repeat(32))
+        now = 1_011L
+        val prefs = Preferences.userRoot().node("orgclock-test/${UUID.randomUUID()}")
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                manager.exchange(SyncPairingExchangeRequest(invitation.token, "phone", "Phone"), DesktopPeerTrustStore(prefs), invitation.certificateSha256)
+            }
+        } finally {
+            prefs.removeNode()
+        }
+    }
+}

--- a/docs/desktop-install.md
+++ b/docs/desktop-install.md
@@ -1,0 +1,29 @@
+# Desktop版のインストール
+
+Desktop版のインストーラは [GitHub Releases](https://github.com/shgnaka/LIFE_LOrG_Clock/releases/latest) から取得できます。
+
+## Windows
+
+1. Latest Release のAssetsから `org-clock-desktop-*.msi` をダウンロードする
+2. `.msi` を実行してインストールする
+3. Windowsの警告が表示された場合は、ReleaseのSHA-256と `SHA256SUMS-windows.txt` を照合してから続行する
+
+## Linux
+
+Debian/Ubuntu系では `.deb`、それ以外ではportable `.tar.gz`を利用できます。
+
+```bash
+sha256sum -c SHA256SUMS-linux.txt
+sudo apt install ./org-clock-desktop_*.deb
+```
+
+portable版の場合:
+
+```bash
+tar -xzf org-clock-desktop-*-linux-portable.tar.gz
+./bin/org-clock-desktop
+```
+
+## リリース方法
+
+`v1.2.3`形式のタグをpushすると、GitHub ActionsがWindowsとLinuxのインストーラを生成し、同じGitHub Releaseへチェックサム付きで公開します。既存タグは`Release Desktop Installers` workflowの手動実行でも再公開できます。

--- a/docs/desktop-manual-smoke-test.md
+++ b/docs/desktop-manual-smoke-test.md
@@ -28,51 +28,57 @@ Desktop MVP は Windows / Linux の起動・配布・基本操作確認を対象
 - `desktopApp/build/compose/binaries/main/` 配下に現在の OS 向け成果物が生成される
 - 少なくとも unpackaged app directory が生成される
 - Windows 環境では `.msi` が確認できる
-- Linux 環境では `.deb` または `.AppImage` が確認できる
+- Linux 環境では `.deb` またはportable `.tar.gz` が確認できる
 
-## 4. First launch behavior
+## 4. GitHub Release install path
+1. `vX.Y.Z` tag build completes in `Release Desktop Installers`
+2. GitHub Release Assets contains Windows `.msi` and Linux `.deb` / portable `.tar.gz`
+3. `SHA256SUMS-windows.txt` and `SHA256SUMS-linux.txt` match downloaded installers
+4. README Latest Release link opens the same release
+
+## 5. First launch behavior
 1. 生成されたアプリを起動する
 2. 初回表示が完了することを確認する
 3. ウィンドウのリサイズ後もレイアウトが破綻しないことを確認する
 
-## 5. Root persistence check
+## 6. Root persistence check
 1. 初回起動で `Choose org root` または `Select local directory` を押す
 2. org root にしたいローカルディレクトリを選ぶ
 3. file list または heading list へ遷移することを確認する
 4. アプリを終了して再起動する
 5. 保存済み root が自動復元され、初回と同じ root で起動することを確認する
 
-## 6. File browsing check
+## 7. File browsing check
 1. root 選択後に file list が表示されることを確認する
 2. `Reload files` で一覧更新ができることを確認する
 3. file を選ぶと heading list に遷移することを確認する
 
-## 7. Navigation and settings check
+## 8. Navigation and settings check
 1. heading list で `Back to files` が動作することを確認する
 2. toolbar の `Settings` から settings 画面へ遷移できることを確認する
 3. settings の `Back` で file list または heading list へ戻れることを確認する
 4. settings の `Change root` で別 root を選び直せることを確認する
 5. settings 画面に Android 専用の notification / permission / sync runtime controls が出ていないことを確認する
 
-## 8. Desktop interaction check
+## 9. Desktop interaction check
 1. heading list で `Start` / `Stop` / `Cancel` / `History` / `Add child heading` が明示ボタンで見えていることを確認する
 2. top toolbar の `Add top-level heading` から create dialog を開けることを確認する
 3. history dialog で `Edit` / `Delete` が long press なしで操作できることを確認する
 4. edit/create/delete dialogs が mouse と keyboard で操作しやすいことを確認する
 
-## 9. Packaging output sanity check
+## 10. Packaging output sanity check
 1. `desktopApp/build/compose/binaries/main/app/` に起動可能ファイル群があることを確認する
 2. 生成された配布物名が `org-clock-desktop` ベースであることを確認する
 3. Windows では `.msi` のインストールとアンインストールが完了することを確認する
 4. Linux では必要なら別の Linux マシンでも起動可否を確認する
 
-## 10. Windows-specific checks
+## 11. Windows-specific checks
 1. `Select local directory` で `C:\\Users\\...` 配下のローカルディレクトリを選択できることを確認する
 2. OneDrive 配下や日本語ディレクトリ名を含む root でも起動・再起動が破綻しないことを確認する
 3. org ファイルを外部エディタで保存したときに `Reload from disk` 導線が表示されることを確認する
 4. 保存済み root を削除した状態で再起動し、root setup 画面に戻れて再選択できることを確認する
 
-## 11. MVP limitations to keep in mind
+## 12. MVP limitations to keep in mind
 - Android notifications / services / WorkManager は対象外
 - Android Storage Access Framework ベースの URI 権限永続化は対象外
 - desktop ではローカル directory picker を使う

--- a/docs/sync-qr-security.md
+++ b/docs/sync-qr-security.md
@@ -1,0 +1,22 @@
+# QRペアリングのセキュリティ
+
+QRコードは恒久的な同期credentialを含みません。内容はDesktopのLAN endpoint、Desktop device ID、自己署名TLS証明書のSHA-256 fingerprint、短期の一回限り招待token、有効期限です。
+
+## 保護
+
+- 招待tokenの有効期間は2分
+- 最初の正常な交換で即時失効し、再利用を拒否
+- 期限切れQRをAndroid側とDesktop側の両方で拒否
+- HTTPSで交換し、QR内fingerprintで証明書をpinning
+- 交換後に端末固有の256-bit credentialを発行
+- 永続credentialはQRへ表示しない
+- Desktopはcredentialと送信元device IDの対応を検証
+- 不正token、証明書不一致、送信元不一致を拒否
+- Androidのcleartext HTTPは引き続き禁止
+- DesktopのTLS秘密鍵はorgルート外の端末ローカル領域に保存し、対応OSでは所有者限定権限を設定
+
+## 残るリスク
+
+攻撃者が表示中のQRを取得し、正規端末より先に2分以内で交換すると、その1台として登録される可能性があります。公共空間ではQRを表示したまま離席せず、登録後にDesktopのtrusted peer一覧を確認してください。不明なpeerはrevokeしてください。
+
+QRはパスワードとして保存・共有しないでください。スクリーンショットを送る運用は想定していません。

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
+    id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 kotlin {
@@ -34,6 +35,7 @@ kotlin {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
             }
         }
         val commonTest by getting {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
             }
         }
         val androidMain by getting {
@@ -63,7 +64,6 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
             }
         }
         val iosArm64Main by getting

--- a/shared/src/commonMain/kotlin/com/example/orgclock/domain/ClockService.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/domain/ClockService.kt
@@ -135,7 +135,7 @@ class ClockService(
 
             val firstLines = runCatching { parser.appendOpenClock(doc.lines, headingPath, now, timeZone) }
                 .getOrElse { return@runExclusive Result.failure(it) }
-            val startedEvent = recordStartedEvent(fileId, doc.date, headingPath, now)
+            val startedEvent = recordStartedEvent(doc.date.toString() + ".org", doc.date, headingPath, now)
             if (startedEvent.isFailure) {
                 return@runExclusive Result.failure(startedEvent.exceptionOrNull()!!)
             }
@@ -193,7 +193,7 @@ class ClockService(
             }
             val closeResult = runCatching { parser.closeLatestOpenClock(doc.lines, headingPath, now, timeZone) }
                 .getOrElse { return@runExclusive Result.failure(it) }
-            val stoppedEvent = recordStoppedEvent(fileId, doc.date, headingPath, now)
+            val stoppedEvent = recordStoppedEvent(doc.date.toString() + ".org", doc.date, headingPath, now)
             if (stoppedEvent.isFailure) {
                 return@runExclusive Result.failure(stoppedEvent.exceptionOrNull()!!)
             }
@@ -221,7 +221,7 @@ class ClockService(
             }
             val cancelled = runCatching { parser.cancelLatestOpenClock(doc.lines, headingPath) }
                 .getOrElse { return@runExclusive Result.failure(it) }
-            val cancelledEvent = recordCancelledEvent(fileId, doc.date, headingPath, Clock.System.now())
+            val cancelledEvent = recordCancelledEvent(doc.date.toString() + ".org", doc.date, headingPath, Clock.System.now())
             if (cancelledEvent.isFailure) {
                 return@runExclusive Result.failure(cancelledEvent.exceptionOrNull()!!)
             }

--- a/shared/src/commonMain/kotlin/com/example/orgclock/sync/ClockEventTransportJsonCodec.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/sync/ClockEventTransportJsonCodec.kt
@@ -1,0 +1,203 @@
+package com.example.orgclock.sync
+
+import com.example.orgclock.model.HeadingPath
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+object ClockEventTransportJsonCodec {
+    fun encodeFetchRequest(value: ClockEventFetchRequest): String =
+        json.encodeToString(FetchRequestWire.serializer(), value.toWire())
+
+    fun decodeFetchRequest(raw: String): ClockEventFetchRequest =
+        json.decodeFromString(FetchRequestWire.serializer(), raw).toModel()
+
+    fun encodeFetchResponse(value: ClockEventFetchResponse): String =
+        json.encodeToString(FetchResponseWire.serializer(), value.toWire())
+
+    fun decodeFetchResponse(raw: String): ClockEventFetchResponse =
+        json.decodeFromString(FetchResponseWire.serializer(), raw).toModel()
+
+    fun encodePushRequest(value: ClockEventPushRequest): String =
+        json.encodeToString(PushRequestWire.serializer(), value.toWire())
+
+    fun decodePushRequest(raw: String): ClockEventPushRequest =
+        json.decodeFromString(PushRequestWire.serializer(), raw).toModel()
+
+    fun encodePushResponse(value: ClockEventPushResponse): String =
+        json.encodeToString(PushResponseWire.serializer(), value.toWire())
+
+    fun decodePushResponse(raw: String): ClockEventPushResponse =
+        json.decodeFromString(PushResponseWire.serializer(), raw).toModel()
+
+    fun encodeAck(value: ClockEventTransportAck): String =
+        json.encodeToString(AckWire.serializer(), value.toWire())
+
+    fun decodeAck(raw: String): ClockEventTransportAck =
+        json.decodeFromString(AckWire.serializer(), raw).toModel()
+
+    fun encodeAckResult(value: ClockEventTransportAckResult): String =
+        json.encodeToString(
+            AckResultWire.serializer(),
+            when (value) {
+                ClockEventTransportAckResult.Accepted -> AckResultWire(accepted = true)
+                is ClockEventTransportAckResult.Rejected -> AckResultWire(false, value.reason)
+            },
+        )
+
+    fun decodeAckResult(raw: String): ClockEventTransportAckResult {
+        val wire = json.decodeFromString(AckResultWire.serializer(), raw)
+        return if (wire.accepted) ClockEventTransportAckResult.Accepted
+        else ClockEventTransportAckResult.Rejected(wire.reason ?: "ack rejected")
+    }
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+}
+
+@Serializable
+private data class FetchRequestWire(
+    val schema: String,
+    val sourcePeerId: String,
+    val targetPeerId: String? = null,
+    val sinceCursor: Long? = null,
+    val batchLimit: Int,
+)
+
+@Serializable
+private data class FetchResponseWire(
+    val schema: String,
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val events: List<StoredEventWire>,
+    val hasMore: Boolean,
+)
+
+@Serializable
+private data class PushRequestWire(
+    val schema: String,
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val events: List<StoredEventWire>,
+)
+
+@Serializable
+private data class PushResponseWire(
+    val schema: String,
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val acceptedCursor: Long? = null,
+    val duplicateEventIds: List<String>,
+    val rejectedEventIds: List<String>,
+    val rejectReason: String? = null,
+)
+
+@Serializable
+private data class AckWire(
+    val schema: String,
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val seenCursor: Long? = null,
+    val acknowledgedEventIds: List<String>,
+    val acknowledgedAt: String,
+)
+
+@Serializable
+private data class AckResultWire(val accepted: Boolean, val reason: String? = null)
+
+@Serializable
+private data class StoredEventWire(val cursor: Long, val event: EventWire)
+
+@Serializable
+private data class EventWire(
+    val schema: String,
+    val eventId: String,
+    val eventType: String,
+    val deviceId: String,
+    val createdAt: String,
+    val logicalDay: String,
+    val fileName: String,
+    val headingPath: List<String>,
+    val causalKind: String,
+    val causalCounter: Long,
+)
+
+private fun ClockEventFetchRequest.toWire() = FetchRequestWire(
+    schema, sourcePeerId, targetPeerId, sinceCursor?.value, batchLimit,
+)
+
+private fun FetchRequestWire.toModel() = ClockEventFetchRequest(
+    schema, sourcePeerId, targetPeerId, sinceCursor?.let(::ClockEventCursor), batchLimit,
+)
+
+private fun ClockEventFetchResponse.toWire() = FetchResponseWire(
+    schema, sourcePeerId, targetPeerId, events.map(StoredClockEvent::toWire), hasMore,
+)
+
+private fun FetchResponseWire.toModel() = ClockEventFetchResponse(
+    schema = schema,
+    sourcePeerId = sourcePeerId,
+    targetPeerId = targetPeerId,
+    events = events.map(StoredEventWire::toModel),
+    hasMore = hasMore,
+)
+
+private fun ClockEventPushRequest.toWire() = PushRequestWire(
+    schema, sourcePeerId, targetPeerId, events.map(StoredClockEvent::toWire),
+)
+
+private fun PushRequestWire.toModel() = ClockEventPushRequest(
+    schema, sourcePeerId, targetPeerId, events.map(StoredEventWire::toModel),
+)
+
+private fun ClockEventPushResponse.toWire() = PushResponseWire(
+    schema, sourcePeerId, targetPeerId, acceptedCursor?.value,
+    duplicateEventIds, rejectedEventIds, rejectReason,
+)
+
+private fun PushResponseWire.toModel() = ClockEventPushResponse(
+    schema, sourcePeerId, targetPeerId, acceptedCursor?.let(::ClockEventCursor),
+    duplicateEventIds, rejectedEventIds, rejectReason,
+)
+
+private fun ClockEventTransportAck.toWire() = AckWire(
+    schema, sourcePeerId, targetPeerId, seenCursor?.value,
+    acknowledgedEventIds, acknowledgedAt.toString(),
+)
+
+private fun AckWire.toModel() = ClockEventTransportAck(
+    schema, sourcePeerId, targetPeerId, seenCursor?.let(::ClockEventCursor),
+    acknowledgedEventIds, Instant.parse(acknowledgedAt),
+)
+
+private fun StoredClockEvent.toWire() = StoredEventWire(
+    cursor.value,
+    EventWire(
+        event.schema,
+        event.eventId,
+        event.eventType.wireValue,
+        event.deviceId,
+        event.createdAt.toString(),
+        event.logicalDay.toString(),
+        event.fileName,
+        event.headingPath.segments,
+        event.causalOrder.kind,
+        event.causalOrder.counter,
+    ),
+)
+
+private fun StoredEventWire.toModel() = StoredClockEvent(
+    ClockEventCursor(cursor),
+    ClockEvent(
+        schema = event.schema,
+        eventId = event.eventId,
+        eventType = ClockEventType.fromWireValue(event.eventType)
+            ?: error("Unsupported event type: ${event.eventType}"),
+        deviceId = event.deviceId,
+        createdAt = Instant.parse(event.createdAt),
+        logicalDay = LocalDate.parse(event.logicalDay),
+        fileName = event.fileName,
+        headingPath = HeadingPath(event.headingPath),
+        causalOrder = ClockEventCausalOrder(event.causalKind, event.causalCounter),
+    ),
+)

--- a/shared/src/commonMain/kotlin/com/example/orgclock/sync/RemoteClockEventApplier.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/sync/RemoteClockEventApplier.kt
@@ -1,0 +1,43 @@
+package com.example.orgclock.sync
+
+import com.example.orgclock.data.ClockRepository
+import com.example.orgclock.domain.ClockService
+import kotlinx.datetime.TimeZone
+
+fun interface RemoteClockEventApplier {
+    suspend fun apply(event: ClockEvent): Result<Unit>
+}
+
+class RepositoryRemoteClockEventApplier(
+    private val repository: ClockRepository,
+    private val clockService: ClockService,
+    private val timeZoneProvider: () -> TimeZone = TimeZone::currentSystemDefault,
+) : RemoteClockEventApplier {
+    override suspend fun apply(event: ClockEvent): Result<Unit> {
+        val file = repository.listOrgFiles()
+            .getOrElse { return Result.failure(it) }
+            .firstOrNull { it.displayName == event.fileName }
+            ?: return Result.failure(IllegalStateException("Target file not found: ${event.fileName}"))
+
+        return when (event.eventType) {
+            ClockEventType.Started -> clockService.startClockInFile(
+                fileId = file.fileId,
+                headingPath = event.headingPath,
+                now = event.createdAt,
+                timeZone = timeZoneProvider(),
+            ).map { Unit }
+
+            ClockEventType.Stopped -> clockService.stopClockInFile(
+                fileId = file.fileId,
+                headingPath = event.headingPath,
+                now = event.createdAt,
+                timeZone = timeZoneProvider(),
+            ).map { Unit }
+
+            ClockEventType.Cancelled -> clockService.cancelClockInFile(
+                fileId = file.fileId,
+                headingPath = event.headingPath,
+            ).map { Unit }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/orgclock/sync/SyncPairingCode.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/sync/SyncPairingCode.kt
@@ -1,0 +1,118 @@
+package com.example.orgclock.sync
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+const val ORG_CLOCK_PAIRING_SCHEMA_V1 = "orgclock.pairing.v1"
+const val ORG_CLOCK_PAIRING_URI_PREFIX = "orgclock://pair?data="
+
+data class SyncPairingCode(
+    val peerId: String,
+    val deviceId: String,
+    val displayName: String,
+    val publicKeyBase64: String,
+    val endpoint: String,
+    val role: PeerTrustRole = PeerTrustRole.Full,
+) {
+    init {
+        require(peerId.isNotBlank()) { "Peer ID cannot be blank." }
+        require(deviceId.isNotBlank()) { "Device ID cannot be blank." }
+        require(displayName.isNotBlank()) { "Display name cannot be blank." }
+        require(publicKeyBase64.isNotBlank()) { "Public key cannot be blank." }
+        require(endpoint.startsWith("http://") || endpoint.startsWith("https://")) {
+            "Endpoint must use HTTP or HTTPS."
+        }
+    }
+
+    fun toRegistrationRequest(requestedAt: Instant): PeerRegistrationRequest =
+        PeerRegistrationRequest(
+            peerId = peerId,
+            deviceId = deviceId,
+            displayName = displayName,
+            publicKeyBase64 = publicKeyBase64,
+            role = role,
+            endpoint = endpoint,
+            requestedAt = requestedAt,
+        )
+}
+
+object SyncPairingCodeCodec {
+    fun encode(code: SyncPairingCode): String {
+        val wire = PairingWire(
+            peerId = code.peerId,
+            deviceId = code.deviceId,
+            displayName = code.displayName,
+            publicKeyBase64 = code.publicKeyBase64,
+            endpoint = code.endpoint,
+            role = code.role.name.lowercase(),
+        )
+        return ORG_CLOCK_PAIRING_URI_PREFIX + percentEncode(json.encodeToString(PairingWire.serializer(), wire))
+    }
+
+    fun decode(raw: String): Result<SyncPairingCode> = runCatching {
+        require(raw.startsWith(ORG_CLOCK_PAIRING_URI_PREFIX)) { "Unsupported pairing code." }
+        val payload = percentDecode(raw.removePrefix(ORG_CLOCK_PAIRING_URI_PREFIX))
+        val wire = json.decodeFromString(PairingWire.serializer(), payload)
+        require(wire.schema == ORG_CLOCK_PAIRING_SCHEMA_V1) { "Unsupported pairing schema: ${wire.schema}" }
+        SyncPairingCode(
+            peerId = wire.peerId.trim(),
+            deviceId = wire.deviceId.trim(),
+            displayName = wire.displayName.trim(),
+            publicKeyBase64 = wire.publicKeyBase64.trim(),
+            endpoint = wire.endpoint.trim().trimEnd('/'),
+            role = when (wire.role.lowercase()) {
+                "full" -> PeerTrustRole.Full
+                "viewer" -> PeerTrustRole.Viewer
+                else -> error("Unsupported peer role: ${wire.role}")
+            },
+        )
+    }
+}
+
+private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+@Serializable
+private data class PairingWire(
+    val schema: String = ORG_CLOCK_PAIRING_SCHEMA_V1,
+    val peerId: String,
+    val deviceId: String,
+    val displayName: String,
+    val publicKeyBase64: String,
+    val endpoint: String,
+    val role: String,
+)
+
+private fun percentEncode(raw: String): String = buildString {
+    raw.encodeToByteArray().forEach { byte ->
+        val value = byte.toInt() and 0xff
+        if (value in 'a'.code..'z'.code || value in 'A'.code..'Z'.code ||
+            value in '0'.code..'9'.code || value == '-'.code || value == '_'.code ||
+            value == '.'.code || value == '~'.code
+        ) {
+            append(value.toChar())
+        } else {
+            append('%')
+            append(HEX[value ushr 4])
+            append(HEX[value and 0x0f])
+        }
+    }
+}
+
+private fun percentDecode(raw: String): String {
+    val bytes = mutableListOf<Byte>()
+    var index = 0
+    while (index < raw.length) {
+        if (raw[index] == '%') {
+            require(index + 2 < raw.length) { "Invalid percent encoding." }
+            bytes += raw.substring(index + 1, index + 3).toInt(16).toByte()
+            index += 3
+        } else {
+            bytes += raw[index].code.toByte()
+            index++
+        }
+    }
+    return bytes.toByteArray().decodeToString()
+}
+
+private const val HEX = "0123456789ABCDEF"

--- a/shared/src/commonMain/kotlin/com/example/orgclock/sync/SyncTransportCredential.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/sync/SyncTransportCredential.kt
@@ -1,0 +1,69 @@
+package com.example.orgclock.sync
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+data class SyncTransportCredential(
+    val pairingSecret: String,
+    val certificateSha256: String,
+) {
+    init {
+        require(pairingSecret.isNotBlank()) { "Pairing secret cannot be blank." }
+        require(certificateSha256.matches(Regex("^[0-9a-fA-F]{64}$"))) {
+            "Certificate fingerprint must be a SHA-256 hex string."
+        }
+    }
+}
+
+data class SyncPairingInvitation(
+    val token: String,
+    val certificateSha256: String,
+    val expiresAtEpochMs: Long,
+) {
+    init {
+        require(token.isNotBlank()) { "Pairing token cannot be blank." }
+        require(certificateSha256.matches(Regex("^[0-9a-fA-F]{64}$"))) { "Invalid certificate fingerprint." }
+        require(expiresAtEpochMs > 0) { "Pairing expiry must be positive." }
+    }
+}
+
+data class SyncPairingExchangeRequest(
+    val invitationToken: String,
+    val deviceId: String,
+    val displayName: String,
+)
+
+data class SyncPairingExchangeResponse(val encodedTransportCredential: String)
+
+object SyncTransportCredentialCodec {
+    private const val PREFIX = "orgclock-https-v1"
+    fun encode(value: SyncTransportCredential): String =
+        "$PREFIX:${value.pairingSecret}:${value.certificateSha256.lowercase()}"
+    fun decode(raw: String): Result<SyncTransportCredential> = runCatching {
+        val parts = raw.split(':', limit = 3)
+        require(parts.size == 3 && parts[0] == PREFIX) { "Unsupported sync credential." }
+        SyncTransportCredential(parts[1], parts[2].lowercase())
+    }
+}
+
+object SyncPairingInvitationCodec {
+    private const val PREFIX = "orgclock-invite-v1"
+    fun encode(value: SyncPairingInvitation): String =
+        "$PREFIX:${value.token}:${value.certificateSha256.lowercase()}:${value.expiresAtEpochMs}"
+    fun decode(raw: String): Result<SyncPairingInvitation> = runCatching {
+        val parts = raw.split(':', limit = 4)
+        require(parts.size == 4 && parts[0] == PREFIX) { "Unsupported pairing invitation." }
+        SyncPairingInvitation(parts[1], parts[2], parts[3].toLong())
+    }
+}
+
+object SyncPairingExchangeJsonCodec {
+    fun encodeRequest(value: SyncPairingExchangeRequest): String = json.encodeToString(RequestWire.serializer(), RequestWire(value.invitationToken, value.deviceId, value.displayName))
+    fun decodeRequest(raw: String): SyncPairingExchangeRequest = json.decodeFromString(RequestWire.serializer(), raw).let { SyncPairingExchangeRequest(it.invitationToken, it.deviceId, it.displayName) }
+    fun encodeResponse(value: SyncPairingExchangeResponse): String = json.encodeToString(ResponseWire.serializer(), ResponseWire(value.encodedTransportCredential))
+    fun decodeResponse(raw: String): SyncPairingExchangeResponse = json.decodeFromString(ResponseWire.serializer(), raw).let { SyncPairingExchangeResponse(it.encodedTransportCredential) }
+    private val json = Json { ignoreUnknownKeys = true }
+}
+
+@Serializable private data class RequestWire(val invitationToken: String, val deviceId: String, val displayName: String)
+@Serializable private data class ResponseWire(val encodedTransportCredential: String)

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiAction.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiAction.kt
@@ -76,6 +76,8 @@ sealed interface OrgClockUiAction {
     data class SyncUpdatePeerDeviceId(val value: String) : OrgClockUiAction
     data class SyncUpdatePeerDisplayName(val value: String) : OrgClockUiAction
     data class SyncUpdatePeerPublicKey(val value: String) : OrgClockUiAction
+    data class SyncUpdatePeerEndpoint(val value: String) : OrgClockUiAction
+    data class SyncApplyPairingCode(val value: String) : OrgClockUiAction
     data class SyncSetPeerViewerMode(val enabled: Boolean) : OrgClockUiAction
     data object SyncAddPeer : OrgClockUiAction
     data class SyncRevokePeer(val peerId: String) : OrgClockUiAction

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiState.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiState.kt
@@ -109,6 +109,7 @@ data class OrgClockUiState(
     val syncPeerDeviceId: String = "",
     val syncPeerDisplayName: String = "",
     val syncPeerPublicKey: String = "",
+    val syncPeerEndpoint: String = "",
     val syncPeerViewerModeEnabled: Boolean = false,
     val syncPeerInputError: String? = null,
     val syncPeerBusy: Boolean = false,

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/store/OrgClockPeerManagementCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/store/OrgClockPeerManagementCoordinator.kt
@@ -24,6 +24,7 @@ class OrgClockPeerManagementCoordinator(
         val deviceId = uiState.value.syncPeerDeviceId.trim()
         val displayName = uiState.value.syncPeerDisplayName.trim().ifBlank { input }
         val publicKey = uiState.value.syncPeerPublicKey.trim()
+        val endpoint = uiState.value.syncPeerEndpoint.trim()
         val validation = validatePeerId(input)
         if (validation != null) {
             uiState.update { it.copy(syncPeerInputError = validation) }
@@ -47,6 +48,7 @@ class OrgClockPeerManagementCoordinator(
             deviceId = deviceId,
             displayName = displayName,
             publicKeyBase64 = publicKey,
+            endpoint = endpoint,
             viewerModeEnabled = uiState.value.syncPeerViewerModeEnabled,
         ).toRegistrationRequest(nowProvider())
         val probe = syncPairTrustedPeer(request)
@@ -61,6 +63,7 @@ class OrgClockPeerManagementCoordinator(
                 syncPeerDeviceId = "",
                 syncPeerDisplayName = "",
                 syncPeerPublicKey = "",
+                syncPeerEndpoint = "",
                 syncPeerViewerModeEnabled = false,
                 syncPeerInputError = null,
                 status = status(StatusMessageKey.SyncPeerAdded, StatusTone.Success, arrayOf(input)),

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/store/OrgClockStore.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/store/OrgClockStore.kt
@@ -18,6 +18,7 @@ import com.example.orgclock.sync.ClockEventStoreSnapshot
 import com.example.orgclock.sync.PeerPairingDraft
 import com.example.orgclock.sync.PeerProbeResult
 import com.example.orgclock.sync.PeerRegistrationRequest
+import com.example.orgclock.sync.SyncPairingCodeCodec
 import com.example.orgclock.sync.PeerTrustRole
 import com.example.orgclock.sync.SyncIntegrationSnapshot
 import com.example.orgclock.sync.toClockEventSyncState
@@ -512,6 +513,26 @@ class OrgClockStore(
         is OrgClockUiAction.SyncUpdatePeerDeviceId -> { _uiState.update { it.copy(syncPeerDeviceId = action.value) }; true }
         is OrgClockUiAction.SyncUpdatePeerDisplayName -> { _uiState.update { it.copy(syncPeerDisplayName = action.value) }; true }
         is OrgClockUiAction.SyncUpdatePeerPublicKey -> { _uiState.update { it.copy(syncPeerPublicKey = action.value) }; true }
+        is OrgClockUiAction.SyncUpdatePeerEndpoint -> { _uiState.update { it.copy(syncPeerEndpoint = action.value) }; true }
+        is OrgClockUiAction.SyncApplyPairingCode -> {
+            SyncPairingCodeCodec.decode(action.value).fold(
+                onSuccess = { code ->
+                    _uiState.update {
+                        it.copy(
+                            syncPeerInput = code.peerId,
+                            syncPeerDeviceId = code.deviceId,
+                            syncPeerDisplayName = code.displayName,
+                            syncPeerPublicKey = code.publicKeyBase64,
+                            syncPeerEndpoint = code.endpoint,
+                            syncPeerViewerModeEnabled = code.role == com.example.orgclock.sync.PeerTrustRole.Viewer,
+                            syncPeerInputError = null,
+                        )
+                    }
+                },
+                onFailure = { error -> _uiState.update { it.copy(syncPeerInputError = error.message ?: "invalid pairing QR code") } },
+            )
+            true
+        }
         is OrgClockUiAction.SyncSetPeerViewerMode -> { _uiState.update { it.copy(syncPeerViewerModeEnabled = action.enabled) }; true }
         OrgClockUiAction.SyncAddPeer -> { scope.launch { addPeer() }; true }
         is OrgClockUiAction.SyncRevokePeer -> { scope.launch { revokePeer(action.peerId) }; true }

--- a/shared/src/commonTest/kotlin/com/example/orgclock/sync/ClockEventTransportJsonCodecTest.kt
+++ b/shared/src/commonTest/kotlin/com/example/orgclock/sync/ClockEventTransportJsonCodecTest.kt
@@ -1,0 +1,42 @@
+package com.example.orgclock.sync
+
+import com.example.orgclock.model.HeadingPath
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClockEventTransportJsonCodecTest {
+    private val stored = StoredClockEvent(
+        cursor = ClockEventCursor(4),
+        event = ClockEvent(
+            eventId = "event-1",
+            eventType = ClockEventType.Stopped,
+            deviceId = "dev-a",
+            createdAt = Instant.parse("2026-06-11T01:02:03Z"),
+            logicalDay = LocalDate.parse("2026-06-11"),
+            fileName = "2026-06-11.org",
+            headingPath = HeadingPath(listOf("Work", "実装")),
+            causalOrder = ClockEventCausalOrder(counter = 8),
+        ),
+    )
+
+    @Test
+    fun fetchPayloadsRoundTrip() {
+        val request = ClockEventFetchRequest("clock.event.transport.v1", "phone", "desktop", ClockEventCursor(3), 64)
+        val response = ClockEventFetchResponse(events = listOf(stored), sourcePeerId = "desktop", targetPeerId = "phone")
+        assertEquals(request, ClockEventTransportJsonCodec.decodeFetchRequest(ClockEventTransportJsonCodec.encodeFetchRequest(request)))
+        assertEquals(response, ClockEventTransportJsonCodec.decodeFetchResponse(ClockEventTransportJsonCodec.encodeFetchResponse(response)))
+    }
+
+    @Test
+    fun pushAndAckPayloadsRoundTrip() {
+        val push = ClockEventPushRequest(sourcePeerId = "phone", targetPeerId = "desktop", events = listOf(stored))
+        val response = ClockEventPushResponse("clock.event.transport.v1", "desktop", "phone", ClockEventCursor(4), listOf("d"), emptyList(), null)
+        val ack = ClockEventTransportAck(sourcePeerId = "phone", targetPeerId = "desktop", seenCursor = ClockEventCursor(4), acknowledgedEventIds = listOf("event-1"), acknowledgedAt = Instant.parse("2026-06-11T01:03:00Z"))
+        assertEquals(push, ClockEventTransportJsonCodec.decodePushRequest(ClockEventTransportJsonCodec.encodePushRequest(push)))
+        assertEquals(response, ClockEventTransportJsonCodec.decodePushResponse(ClockEventTransportJsonCodec.encodePushResponse(response)))
+        assertEquals(ack, ClockEventTransportJsonCodec.decodeAck(ClockEventTransportJsonCodec.encodeAck(ack)))
+        assertEquals(ClockEventTransportAckResult.Accepted, ClockEventTransportJsonCodec.decodeAckResult(ClockEventTransportJsonCodec.encodeAckResult(ClockEventTransportAckResult.Accepted)))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/example/orgclock/sync/RemoteClockEventApplierTest.kt
+++ b/shared/src/commonTest/kotlin/com/example/orgclock/sync/RemoteClockEventApplierTest.kt
@@ -1,0 +1,64 @@
+package com.example.orgclock.sync
+
+import com.example.orgclock.data.ClockRepository
+import com.example.orgclock.data.FileWriteIntent
+import com.example.orgclock.data.OrgFileEntry
+import com.example.orgclock.data.SaveResult
+import com.example.orgclock.domain.ClockService
+import com.example.orgclock.model.HeadingPath
+import com.example.orgclock.model.OrgDocument
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+
+class RemoteClockEventApplierTest {
+    @Test
+    fun appliesStartedEventToFileResolvedByPortableDisplayName() = runTest {
+        val repository = MemoryRepository()
+        val applier = RepositoryRemoteClockEventApplier(
+            repository = repository,
+            clockService = ClockService(repository),
+            timeZoneProvider = { TimeZone.UTC },
+        )
+
+        val result = applier.apply(
+            ClockEvent(
+                eventId = "evt-remote",
+                eventType = ClockEventType.Started,
+                deviceId = "phone",
+                createdAt = Instant.parse("2026-06-11T09:00:00Z"),
+                logicalDay = LocalDate(2026, 6, 11),
+                fileName = "2026-06-11.org",
+                headingPath = HeadingPath.parse("Work/Project"),
+                causalOrder = ClockEventCausalOrder(counter = 1),
+            ),
+        )
+
+        assertTrue(result.isSuccess)
+        assertContains(repository.lines, "CLOCK: [2026-06-11 Thu 09:00:00]")
+    }
+}
+
+private class MemoryRepository : ClockRepository {
+    var lines = listOf("* Work", "** Project", ":LOGBOOK:", ":END:")
+    private val date = LocalDate(2026, 6, 11)
+
+    override suspend fun listOrgFiles() = Result.success(
+        listOf(OrgFileEntry(fileId = "platform-specific-id", displayName = "2026-06-11.org", modifiedAt = null)),
+    )
+
+    override suspend fun loadFile(fileId: String) = Result.success(OrgDocument(date, lines, "hash"))
+
+    override suspend fun saveFile(fileId: String, lines: List<String>, expectedHash: String, writeIntent: FileWriteIntent): SaveResult {
+        this.lines = lines
+        return SaveResult.Success
+    }
+
+    override suspend fun loadDaily(date: LocalDate) = loadFile("platform-specific-id")
+    override suspend fun saveDaily(date: LocalDate, lines: List<String>, expectedHash: String) =
+        saveFile("platform-specific-id", lines, expectedHash)
+}

--- a/shared/src/commonTest/kotlin/com/example/orgclock/sync/SyncPairingCodeTest.kt
+++ b/shared/src/commonTest/kotlin/com/example/orgclock/sync/SyncPairingCodeTest.kt
@@ -1,0 +1,41 @@
+package com.example.orgclock.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncPairingCodeTest {
+    @Test
+    fun roundTripsUnicodeAndEndpoint() {
+        val code = SyncPairingCode(
+            peerId = "192.168.1.20:8787",
+            deviceId = "dev-desktop",
+            displayName = "仕事用 PC",
+            publicKeyBase64 = "pairing-secret",
+            endpoint = "http://192.168.1.20:8787",
+        )
+
+        val encoded = SyncPairingCodeCodec.encode(code)
+        val decoded = SyncPairingCodeCodec.decode(encoded).getOrThrow()
+
+        assertTrue(encoded.startsWith(ORG_CLOCK_PAIRING_URI_PREFIX))
+        assertEquals(code, decoded)
+    }
+
+    @Test
+    fun rejectsUnknownScheme() {
+        assertTrue(SyncPairingCodeCodec.decode("https://example.com").isFailure)
+    }
+}
+
+class SyncTransportCredentialTest {
+    @Test
+    fun credentialRoundTrips() {
+        val credential = SyncTransportCredential("secret", "ab".repeat(32))
+        assertEquals(credential, SyncTransportCredentialCodec.decode(SyncTransportCredentialCodec.encode(credential)).getOrThrow())
+        val invitation = SyncPairingInvitation("one-time", "cd".repeat(32), 123456L)
+        assertEquals(invitation, SyncPairingInvitationCodec.decode(SyncPairingInvitationCodec.encode(invitation)).getOrThrow())
+        val exchange = SyncPairingExchangeRequest("one-time", "phone-1", "Phone")
+        assertEquals(exchange, SyncPairingExchangeJsonCodec.decodeRequest(SyncPairingExchangeJsonCodec.encodeRequest(exchange)))
+    }
+}


### PR DESCRIPTION
## What changed
- add Android QR scanning and HTTPS LAN pairing with certificate pinning
- use two-minute, one-time QR invitations and issue per-device durable credentials only after exchange
- apply received clock events to portable org file names and prevent event relay loops
- add Desktop QR UI, persistent TLS identity, LAN sync server, and pairing tests
- add GitHub Actions release publishing for Windows MSI, Linux DEB, portable tarball, and SHA-256 files
- add README installation links and QR threat-model documentation

## Security
The QR contains no durable credential. It carries a short-lived one-time invitation, endpoint, expiry, and certificate fingerprint. The TLS private key is stored outside the org root in a device-local directory with owner-only POSIX permissions where supported.

## Validation
- `./gradlew :shared:jvmTest --no-daemon -Pkotlin.incremental=false`
- `./gradlew :desktopApp:test --no-daemon -Pkotlin.incremental=false`
- `./gradlew packageDesktopCurrentOs -Pdesktop.version=0.0.0-test --no-daemon -Pkotlin.incremental=false`
- GitHub Actions YAML parsed successfully
- `git diff --check`

Android compilation is currently blocked before Kotlin compilation because the local Windows Android SDK Build Tools 34.0.0 installation exposes `aapt.exe` but WSL Gradle expects `aapt`. The failure reports the SDK installation as corrupted; it is not a source compilation failure.