### PR TITLE
[codex] Define semantic versioning policy

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -37,7 +37,11 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
-          [[ "$TAG" == v* ]] || { echo "::error::Release tag must start with v"; exit 1; }
+          SEMVER='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          [[ "$TAG" =~ $SEMVER ]] || {
+            echo "::error::Release tag must be SemVer (for example v1.2.3 or v1.2.3-rc.1)"
+            exit 1
+          }
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Gradle files
 .gradle/
+.kotlin/
 build/
+
+# Local agent/runtime workspaces
+.codex
+_winrun/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@
 - [Android 実機インストール手順](docs/install-debug-guide.md)
 - [Android 手動スモークテスト](docs/manual-smoke-test.md)
 - [Desktop MVP 手動スモークテスト（Windows / Linux）](docs/desktop-manual-smoke-test.md)
+- [バージョニング方針](docs/versioning.md)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,85 @@
+# Versioning policy
+
+Org Clock follows [Semantic Versioning 2.0.0](https://semver.org/) for product
+releases.
+
+## Product version
+
+The canonical release version is the Git tag:
+
+```text
+vMAJOR.MINOR.PATCH
+```
+
+For example, tag `v1.4.2` represents product version `1.4.2`. Android, iOS, and
+desktop builds released from the same commit use the same product version.
+
+- `MAJOR`: incompatible changes to user data, sync/network compatibility, or
+  documented external behavior that require users or integrations to migrate.
+- `MINOR`: backward-compatible features or meaningful capability additions.
+- `PATCH`: backward-compatible bug, security, performance, documentation, and
+  internal maintenance changes.
+
+When several change types are present, use the highest required increment.
+Version numbers are never reused after publication.
+
+## Before 1.0.0
+
+Versions below `1.0.0` indicate that compatibility is not yet guaranteed.
+
+- Breaking changes increment `MINOR`.
+- Backward-compatible features increment `MINOR`.
+- Backward-compatible fixes increment `PATCH`.
+
+The first release that promises stable user-data and sync compatibility is
+`1.0.0`.
+
+## Pre-releases
+
+Unstable release candidates use SemVer pre-release identifiers:
+
+```text
+v1.3.0-alpha.1
+v1.3.0-beta.1
+v1.3.0-rc.1
+```
+
+Increment the numeric suffix for each candidate. A stable release removes the
+suffix. Build metadata such as `+sha.abc1234` may identify local or CI builds,
+but it does not change release precedence and should not be used for public
+release tags.
+
+## Platform build numbers
+
+Store-facing build numbers are not part of SemVer:
+
+- Android `versionName` is the product version; `versionCode` is a
+  monotonically increasing integer.
+- iOS `CFBundleShortVersionString` is the product version;
+  `CFBundleVersion` is a monotonically increasing integer.
+- Desktop package versions are derived from the Git tag without the leading
+  `v`.
+
+Rebuilding an existing product version for a store may increment only the
+platform build number. It must not replace or move an existing Git tag or
+GitHub Release.
+
+## Compatibility scope
+
+The product version covers the shipped application as a whole. Internal
+database migrations, serialized payloads, and sync protocol schemas retain
+their own schema versions. Changing an internal schema does not by itself
+require a product `MAJOR` increment when the app migrates old data and remains
+compatible with supported peers.
+
+Use a `MAJOR` increment when a release intentionally drops that compatibility,
+requires manual migration, or cannot interoperate with supported released
+versions.
+
+## Release procedure
+
+1. Select the next version from changes since the latest release.
+2. Update platform product versions and monotonically increasing build numbers.
+3. Verify release builds and migration/sync compatibility.
+4. Create an annotated `vMAJOR.MINOR.PATCH` tag, or a permitted pre-release tag.
+5. Push the tag and publish generated release notes and artifacts.


### PR DESCRIPTION
## Summary

- define a repository-wide Semantic Versioning policy
- document product versions, pre-releases, platform build numbers, and compatibility scope
- link the policy from the README
- validate desktop release tags as SemVer in GitHub Actions
- ignore local Kotlin and Codex runtime artifacts

## Why

The repository already publishes desktop artifacts from version tags, while platform and compatibility versioning expectations were not formally defined. This establishes one product version policy across Android, iOS, and desktop and prevents malformed release tags from publishing.

## Validation

- `git diff --check origin/main..HEAD`
- verified tag validation accepts `v1.2.3` and `v1.2.3-rc.1`
- verified malformed and build-metadata release tags are rejected