### PR TITLE
[codex] Support desktop prerelease publishing

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -44,6 +44,8 @@ jobs:
           }
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          [[ "$TAG" == *-* ]] && IS_PRERELEASE=true || IS_PRERELEASE=false
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release tag
         uses: actions/checkout@v4
@@ -100,7 +102,13 @@ jobs:
     steps:
       - name: Resolve release tag
         id: release
-        run: echo "tag=${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          [[ "$TAG" == *-* ]] && IS_PRERELEASE=true || IS_PRERELEASE=false
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Download installers
         uses: actions/download-artifact@v4
@@ -114,5 +122,6 @@ jobs:
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           generate_release_notes: true
+          prerelease: ${{ steps.release.outputs.is_prerelease }}
           files: release-assets/*
           fail_on_unmatched_files: true

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -6,6 +6,9 @@ val desktopPackageVersion = providers.gradleProperty("desktop.version")
     .getOrElse("1.0.0")
     .removePrefix("v")
 
+// MSI only accepts a numeric MAJOR.MINOR.BUILD version.
+val desktopMsiPackageVersion = desktopPackageVersion.substringBefore("-")
+
 val desktopTargetFormats = when {
     org.gradle.internal.os.OperatingSystem.current().isMacOsX -> arrayOf(TargetFormat.Dmg)
     org.gradle.internal.os.OperatingSystem.current().isWindows -> arrayOf(TargetFormat.Msi)
@@ -51,6 +54,10 @@ compose.desktop {
             packageVersion = desktopPackageVersion
             description = "Cross-platform desktop MVP host for Org Clock."
             vendor = "shgnaka"
+
+            windows {
+                msiPackageVersion = desktopMsiPackageVersion
+            }
         }
     }
 }

--- a/docs/desktop-install.md
+++ b/docs/desktop-install.md
@@ -26,4 +26,4 @@ tar -xzf org-clock-desktop-*-linux-portable.tar.gz
 
 ## リリース方法
 
-`v1.2.3`形式のタグをpushすると、GitHub ActionsがWindowsとLinuxのインストーラを生成し、同じGitHub Releaseへチェックサム付きで公開します。既存タグは`Release Desktop Installers` workflowの手動実行でも再公開できます。
+`v1.2.3`形式のタグをpushすると、GitHub ActionsがWindowsとLinuxのインストーラを生成し、同じGitHub Releaseへチェックサム付きで公開します。`v1.2.3-rc.1`のようなプレリリースタグも利用でき、その場合はGitHub ReleaseのPre-releaseフラグが自動的に有効になります。既存タグは`Release Desktop Installers` workflowの手動実行でも再公開できます。

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -72,7 +72,9 @@ Store-facing build numbers are not part of SemVer:
 - iOS `CFBundleShortVersionString` is the product version;
   `CFBundleVersion` is a monotonically increasing integer.
 - Desktop package versions are derived from the Git tag without the leading
-  `v`.
+  `v`. Windows MSI metadata uses the numeric `MAJOR.MINOR.PATCH` portion because
+  MSI does not accept SemVer pre-release identifiers; the Git tag, GitHub
+  Release, and installer filename retain the complete pre-release version.
 
 Rebuilding an existing product version for a store may increment only the
 platform build number. It must not replace or move an existing Git tag or

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -49,6 +49,20 @@ suffix. Build metadata such as `+sha.abc1234` may identify local or CI builds,
 but it does not change release precedence and should not be used for public
 release tags.
 
+Pushing a pre-release tag runs the `Release Desktop Installers` workflow. The
+workflow builds the Windows and Linux installers and publishes the associated
+GitHub Release with its **Pre-release** flag enabled.
+
+For example, create and push the first `1.0.0` release candidate with:
+
+```bash
+git tag -a v1.0.0-rc.1 -m "Org Clock v1.0.0-rc.1"
+git push origin v1.0.0-rc.1
+```
+
+Do not move or reuse a published pre-release tag. Fix the problem and increment
+the suffix, for example from `rc.1` to `rc.2`.
+
 ## Platform build numbers
 
 Store-facing build numbers are not part of SemVer:
@@ -82,4 +96,6 @@ versions.
 2. Update platform product versions and monotonically increasing build numbers.
 3. Verify release builds and migration/sync compatibility.
 4. Create an annotated `vMAJOR.MINOR.PATCH` tag, or a permitted pre-release tag.
-5. Push the tag and publish generated release notes and artifacts.
+5. Push the tag. The desktop release workflow publishes generated release notes,
+   installers, and checksums; pre-release tags are marked as GitHub
+   Pre-releases.


### PR DESCRIPTION
## Summary

- detect SemVer prerelease tags and mark generated GitHub Releases as prereleases
- preserve the full prerelease version for Linux artifacts while using the numeric version required by MSI metadata
- document the prerelease tagging and desktop publishing procedure

## Why

The desktop release workflow accepted tags such as `v1.0.0-rc.1`, but it did not mark the resulting GitHub Release as a prerelease. Windows MSI packaging also rejects SemVer prerelease identifiers in its internal package version.

## Validation

- `v1.0.0-rc.2` triggered `Release Desktop Installers`
- Windows installer build succeeded
- Linux installer build succeeded
- publish job succeeded
- GitHub Release was published with `prerelease: true`
- release assets include MSI, DEB, Linux portable archive, and SHA-256 checksum files

Release: https://github.com/shgnaka/LIFE_LOrG_Clock/releases/tag/v1.0.0-rc.2
Actions: https://github.com/shgnaka/LIFE_LOrG_Clock/actions/runs/27380867657