### PR TITLE
Share templates across devices and add Windows installer smoke tests

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -66,6 +66,13 @@ jobs:
           chmod +x ./gradlew
           ./gradlew --stacktrace packageDesktopCurrentOs -Pdesktop.version="${{ steps.release.outputs.version }}"
 
+      - name: Smoke test Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & .\scripts\desktop-smoke-test.ps1 -SkipBuild
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Collect Linux installers
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/verify-desktop-windows.yml
+++ b/.github/workflows/verify-desktop-windows.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/verify-desktop-linux.yml"
       - ".github/workflows/verify-desktop-windows.yml"
       - "desktopApp/**"
+      - "scripts/desktop-smoke-test.ps1"
       - "shared/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
@@ -23,6 +24,7 @@ on:
       - ".github/workflows/verify-desktop-linux.yml"
       - ".github/workflows/verify-desktop-windows.yml"
       - "desktopApp/**"
+      - "scripts/desktop-smoke-test.ps1"
       - "shared/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
@@ -76,6 +78,12 @@ jobs:
           & .\gradlew.bat --stacktrace packageDesktopCurrentOs *>&1 | Tee-Object -FilePath artifacts/desktop-windows/package-desktop-current-os.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Smoke test installed Windows package
+        shell: pwsh
+        run: |
+          & .\scripts\desktop-smoke-test.ps1 -SkipBuild
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload desktop artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -84,3 +92,4 @@ jobs:
           path: |
             desktopApp/build/compose/binaries/main
             artifacts/desktop-windows
+            artifacts/desktop-smoke

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Gradle files
 .gradle/
+.gradle-*/
 .kotlin/
 build/
 
@@ -13,6 +14,7 @@ local.properties
 # Log/OS Files
 *.log
 artifacts/ci/
+artifacts/desktop-smoke/
 
 # Android Studio generated files and folders
 captures/

--- a/app/src/main/java/com/example/orgclock/di/AppGraph.kt
+++ b/app/src/main/java/com/example/orgclock/di/AppGraph.kt
@@ -54,6 +54,8 @@ import com.example.orgclock.template.TemplateAutoGenerationEntryPoint
 import com.example.orgclock.template.TemplateAutoGenerationRuntimeStore
 import com.example.orgclock.template.TemplateAutoGenerationScheduler
 import com.example.orgclock.template.TemplateSyncService
+import com.example.orgclock.template.AndroidSharedTemplateStore
+import com.example.orgclock.template.TemplateSharingService
 import androidx.lifecycle.lifecycleScope
 import com.example.orgclock.time.ClockEnvironment
 import com.example.orgclock.time.SystemClockEnvironment
@@ -127,6 +129,18 @@ class DefaultAppGraph(
                 prefs.getString(NotificationPrefs.KEY_ROOT_URI, null)
                     ?.let { rootScheduleStore.load(it).templateFileUri }
             },
+        )
+    }
+    private val sharedTemplateStore by lazy {
+        AndroidSharedTemplateStore(
+            repository = safRepository,
+            preferences = prefs,
+            rootUriProvider = { prefs.getString(NotificationPrefs.KEY_ROOT_URI, null) },
+            templateFileUriProvider = {
+                prefs.getString(NotificationPrefs.KEY_ROOT_URI, null)
+                    ?.let { rootScheduleStore.load(it).templateFileUri }
+            },
+            deviceIdProvider = deviceIdProvider::getOrCreate,
         )
     }
     private val templateAutoGenerationScheduler by lazy {
@@ -362,6 +376,24 @@ class DefaultAppGraph(
             },
             syncTemplateTaggedHeading = { fileId ->
                 templateSyncService.syncFromFile(fileId)
+            },
+            syncTemplateNow = {
+                runCatching {
+                    val localPeerId = deviceIdProvider.getOrCreate()
+                    val peer = peerTrustStore.listTrustRecords()
+                        .firstOrNull {
+                            it.isActive &&
+                                it.role == com.example.orgclock.sync.PeerTrustRole.Full &&
+                                it.endpoint != null
+                        }
+                        ?: error("No paired full-access device is available")
+                    TemplateSharingService(
+                        localStore = sharedTemplateStore,
+                        transport = AndroidLanSyncTransport(peer.endpoint!!, peer.publicKeyBase64),
+                        localPeerId = localPeerId,
+                        remotePeerId = peer.peerId,
+                    ).synchronize().getOrThrow()
+                }
             },
             syncNotificationService = { enabled, mode ->
                 ClockInNotificationService.sync(

--- a/app/src/main/java/com/example/orgclock/sync/AndroidLanSyncTransport.kt
+++ b/app/src/main/java/com/example/orgclock/sync/AndroidLanSyncTransport.kt
@@ -10,13 +10,19 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import com.example.orgclock.template.TemplateFetchRequest
+import com.example.orgclock.template.TemplateFetchResponse
+import com.example.orgclock.template.TemplatePushRequest
+import com.example.orgclock.template.TemplatePushResult
+import com.example.orgclock.template.TemplateSharingJsonCodec
+import com.example.orgclock.template.TemplateSyncTransport
 
 class AndroidLanSyncTransport(
     endpoint: String,
     encodedCredential: String,
     private val connectTimeoutMs: Int = 5_000,
     private val readTimeoutMs: Int = 10_000,
-) : ClockEventSyncTransport {
+) : ClockEventSyncTransport, TemplateSyncTransport {
     private val endpoint = endpoint.trimEnd('/')
     private val credential = SyncTransportCredentialCodec.decode(encodedCredential).getOrThrow()
     private val sslContext = pinnedSslContext(credential.certificateSha256)
@@ -29,6 +35,16 @@ class AndroidLanSyncTransport(
 
     override suspend fun acknowledge(ack: ClockEventTransportAck): ClockEventTransportAckResult =
         ClockEventTransportJsonCodec.decodeAckResult(post("/v1/events/ack", ClockEventTransportJsonCodec.encodeAck(ack)))
+
+    override suspend fun fetchTemplate(request: TemplateFetchRequest): TemplateFetchResponse =
+        TemplateSharingJsonCodec.decodeFetchResponse(
+            post("/v1/template/fetch", TemplateSharingJsonCodec.encodeFetchRequest(request)),
+        )
+
+    override suspend fun pushTemplate(request: TemplatePushRequest): TemplatePushResult =
+        TemplateSharingJsonCodec.decodePushResult(
+            post("/v1/template/push", TemplateSharingJsonCodec.encodePushRequest(request)),
+        )
 
     suspend fun probe(): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {

--- a/app/src/main/java/com/example/orgclock/template/AndroidSharedTemplateStore.kt
+++ b/app/src/main/java/com/example/orgclock/template/AndroidSharedTemplateStore.kt
@@ -1,0 +1,110 @@
+package com.example.orgclock.template
+
+import android.content.SharedPreferences
+import com.example.orgclock.data.SafOrgRepository
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+class AndroidSharedTemplateStore(
+    private val repository: SafOrgRepository,
+    private val preferences: SharedPreferences,
+    private val rootUriProvider: () -> String?,
+    private val templateFileUriProvider: () -> String?,
+    private val deviceIdProvider: () -> String,
+) : SharedTemplateStore {
+    override suspend fun readRevision(): Result<SharedTemplateRevision?> = runCatching {
+        val rootUri = rootUriProvider() ?: error("org root is not configured")
+        val templateFileUri = templateFileUriProvider()
+        val status = repository.inspectTemplateFile(templateFileUri).getOrThrow()
+        if (status.availability == TemplateAvailability.Missing) return@runCatching null
+        require(status.availability == TemplateAvailability.Available) {
+            status.detailMessage ?: "Template is not readable"
+        }
+        val template = repository.loadTemplate(templateFileUri).getOrThrow()
+        val content = template.lines.joinToString("\n")
+        val contentHash = stableHash(content)
+        val prefix = prefix(rootUri, templateFileUri)
+        val storedHash = preferences.getString("${prefix}content_hash", null)
+        val storedRevision = preferences.getString("${prefix}revision_id", null)
+        val revisionId = if (storedHash == contentHash && storedRevision != null) {
+            storedRevision
+        } else {
+            "sha256:$contentHash".also {
+                persistMetadata(prefix, it, storedRevision, contentHash, Clock.System.now(), deviceIdProvider())
+            }
+        }
+        SharedTemplateRevision(
+            revisionId = revisionId,
+            parentRevisionId = preferences.getString("${prefix}parent_revision_id", null),
+            content = content,
+            contentHash = contentHash,
+            updatedAt = preferences.getString("${prefix}updated_at", null)
+                ?.let(Instant::parse) ?: Clock.System.now(),
+            updatedByDeviceId = preferences.getString("${prefix}updated_by", null) ?: deviceIdProvider(),
+        )
+    }
+
+    override suspend fun writeRevision(
+        revision: SharedTemplateRevision,
+        expectedCurrentRevisionId: String?,
+    ): Result<TemplatePushResult> = runCatching {
+        val current = readRevision().getOrThrow()
+        if (current?.revisionId != expectedCurrentRevisionId) {
+            return@runCatching TemplatePushResult.Conflict(current?.revisionId, revision.revisionId)
+        }
+        require(stableHash(revision.content) == revision.contentHash) { "Template content hash mismatch" }
+        val existing = repository.loadTemplate(templateFileUriProvider()).getOrThrow()
+        when (
+            val saved = repository.saveTemplate(
+                lines = revision.content.split('\n').let { if (it.lastOrNull().isNullOrEmpty()) it.dropLast(1) else it },
+                expectedHash = existing.hash,
+                templateFileUri = templateFileUriProvider(),
+            )
+        ) {
+            com.example.orgclock.data.SaveResult.Success -> Unit
+            is com.example.orgclock.data.SaveResult.Conflict -> error(saved.reason)
+            is com.example.orgclock.data.SaveResult.IoError -> error(saved.reason)
+            is com.example.orgclock.data.SaveResult.RoundTripMismatch -> error(saved.reason)
+            is com.example.orgclock.data.SaveResult.ValidationError -> error(saved.reason)
+        }
+        val prefix = prefix(
+            rootUriProvider() ?: error("org root is not configured"),
+            templateFileUriProvider(),
+        )
+        persistMetadata(
+            prefix,
+            revision.revisionId,
+            revision.parentRevisionId,
+            revision.contentHash,
+            revision.updatedAt,
+            revision.updatedByDeviceId,
+        )
+        TemplatePushResult.Accepted(revision.revisionId)
+    }
+
+    private fun persistMetadata(
+        prefix: String,
+        revisionId: String,
+        parentRevisionId: String?,
+        contentHash: String,
+        updatedAt: Instant,
+        updatedBy: String,
+    ) {
+        preferences.edit()
+            .putString("${prefix}revision_id", revisionId)
+            .putString("${prefix}parent_revision_id", parentRevisionId)
+            .putString("${prefix}content_hash", contentHash)
+            .putString("${prefix}updated_at", updatedAt.toString())
+            .putString("${prefix}updated_by", updatedBy)
+            .apply()
+    }
+
+    private fun prefix(rootUri: String, templateFileUri: String?): String =
+        "shared_template_${stableHash("$rootUri\n${templateFileUri.orEmpty()}")}_"
+
+    private fun stableHash(value: String): String =
+        MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockRoute.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockRoute.kt
@@ -32,6 +32,7 @@ import com.example.orgclock.sync.SyncIntegrationSnapshot
 import com.example.orgclock.template.RootScheduleConfig
 import com.example.orgclock.template.TemplateAutoGenerationRuntimeState
 import com.example.orgclock.template.TemplateFileStatus
+import com.example.orgclock.template.TemplateSyncOutcome
 import com.example.orgclock.ui.store.OrgClockStore
 import com.example.orgclock.ui.perf.PerformanceMonitor
 import com.example.orgclock.ui.state.OrgClockUiAction
@@ -77,6 +78,9 @@ data class OrgClockRouteDependencies(
     val syncRootScheduleConfig: suspend (RootScheduleConfig) -> Unit,
     val runAutoGenerationCatchUp: suspend (RootReference) -> Unit,
     val syncTemplateTaggedHeading: suspend (String) -> Result<Boolean> = { Result.success(false) },
+    val syncTemplateNow: suspend () -> Result<TemplateSyncOutcome> = {
+        Result.failure(UnsupportedOperationException("template sharing unavailable"))
+    },
     val syncNotificationService: (Boolean, NotificationDisplayMode) -> Unit,
     val stopNotificationService: () -> Unit,
     val openAppNotificationSettings: () -> Unit,
@@ -273,6 +277,7 @@ private fun orgClockViewModelFactory(
                 syncRootScheduleConfig = dependencies.syncRootScheduleConfig,
                 runAutoGenerationCatchUp = dependencies.runAutoGenerationCatchUp,
                 syncTemplateTaggedHeading = dependencies.syncTemplateTaggedHeading,
+                syncTemplateNow = dependencies.syncTemplateNow,
                 syncSnapshotFlow = dependencies.syncSnapshotFlow,
                 clockEventSyncSnapshotFlow = dependencies.clockEventSyncSnapshotFlow,
                 syncPairTrustedPeer = dependencies.syncPairTrustedPeer,

--- a/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
+++ b/app/src/main/java/com/example/orgclock/ui/app/OrgClockScreen.kt
@@ -252,6 +252,8 @@ fun OrgClockScreen(
                 autoGenerationRuntimeState = state.autoGenerationRuntimeState,
                 templateFileStatus = state.templateFileStatus,
                 templateAutoGenerationFailure = state.templateAutoGenerationFailure,
+                templateSyncInProgress = state.templateSyncInProgress,
+                templateSyncMessage = state.templateSyncMessage,
                 syncFeatureVisible = state.syncFeatureVisible,
                 syncDebugVisible = state.syncDebugVisible,
                 syncRuntimeEnabled = state.syncRuntimeEnabled,
@@ -303,6 +305,7 @@ fun OrgClockScreen(
                 },
                 onOpenTemplateFilePicker = { onAction(OrgClockUiAction.OpenTemplateFilePicker) },
                 onClearExplicitTemplateFile = { onAction(OrgClockUiAction.ClearExplicitTemplateFile) },
+                onSyncTemplateNow = { onAction(OrgClockUiAction.SyncTemplateNow) },
                 onSyncFlushNow = { onAction(OrgClockUiAction.SyncFlushNow) },
                 onSyncEnableStandard = { onAction(OrgClockUiAction.SyncEnableStandard) },
                 onSyncEnableActive = { onAction(OrgClockUiAction.SyncEnableActive) },
@@ -390,6 +393,11 @@ private fun RootSetupScreen(
                 Button(onClick = onPickRoot) {
                     Text(stringResource(R.string.select_org_directory))
                 }
+                Text(
+                    "After choosing a root, you can use its template or download a template from a paired device.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }
@@ -1017,6 +1025,8 @@ private fun SettingsScreen(
     autoGenerationRuntimeState: TemplateAutoGenerationRuntimeState,
     templateFileStatus: TemplateFileStatus,
     templateAutoGenerationFailure: String?,
+    templateSyncInProgress: Boolean,
+    templateSyncMessage: String?,
     syncFeatureVisible: Boolean,
     syncDebugVisible: Boolean,
     syncRuntimeEnabled: Boolean,
@@ -1050,6 +1060,7 @@ private fun SettingsScreen(
     onSaveAutoGenerationSchedule: () -> Unit,
     onOpenTemplateFilePicker: () -> Unit,
     onClearExplicitTemplateFile: () -> Unit,
+    onSyncTemplateNow: () -> Unit,
     onSyncFlushNow: () -> Unit,
     onSyncEnableStandard: () -> Unit,
     onSyncEnableActive: () -> Unit,
@@ -1241,6 +1252,9 @@ private fun SettingsScreen(
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = onSyncTemplateNow, enabled = !templateSyncInProgress) {
+                        Text(if (templateSyncInProgress) "Synchronizing..." else "Sync with paired device")
+                    }
                     Button(onClick = onOpenTemplateFilePicker) {
                         Text(stringResource(R.string.template_choose_file))
                     }
@@ -1249,6 +1263,17 @@ private fun SettingsScreen(
                             Text(stringResource(R.string.template_use_legacy))
                         }
                     }
+                }
+                templateSyncMessage?.let { message ->
+                    Text(
+                        text = message,
+                        color = if (message.contains("conflict", true) || message.contains("failed", true)) {
+                            StateWarningFg
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                    )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Button(

--- a/app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt
+++ b/app/src/main/java/com/example/orgclock/ui/viewmodel/OrgClockViewModel.kt
@@ -16,6 +16,7 @@ import com.example.orgclock.sync.SyncIntegrationSnapshot
 import com.example.orgclock.template.RootScheduleConfig
 import com.example.orgclock.template.TemplateAutoGenerationRuntimeState
 import com.example.orgclock.template.TemplateFileStatus
+import com.example.orgclock.template.TemplateSyncOutcome
 import com.example.orgclock.time.toKotlinInstantCompat
 import com.example.orgclock.time.toKotlinLocalDateCompat
 import com.example.orgclock.ui.state.OrgClockUiAction
@@ -56,6 +57,9 @@ class OrgClockViewModel(
     syncRootScheduleConfig: suspend (RootScheduleConfig) -> Unit,
     runAutoGenerationCatchUp: suspend (RootReference) -> Unit,
     createDefaultTemplateFile: suspend (RootReference) -> Result<String> = { Result.failure(UnsupportedOperationException("template file creation unavailable")) },
+    syncTemplateNow: suspend () -> Result<TemplateSyncOutcome> = {
+        Result.failure(UnsupportedOperationException("template sharing unavailable"))
+    },
     syncTemplateTaggedHeading: suspend (String) -> Result<Boolean> = { Result.success(false) },
     syncSnapshotFlow: StateFlow<SyncIntegrationSnapshot> = MutableStateFlow(SyncIntegrationSnapshot()),
     clockEventSyncSnapshotFlow: StateFlow<ClockEventStoreSnapshot> = OrgClockStore.NO_CLOCK_EVENT_SYNC_SNAPSHOT_FLOW,
@@ -120,6 +124,7 @@ class OrgClockViewModel(
         syncRootScheduleConfig = syncRootScheduleConfig,
         runAutoGenerationCatchUp = runAutoGenerationCatchUp,
         createDefaultTemplateFileAction = createDefaultTemplateFile,
+        syncTemplateNow = syncTemplateNow,
         syncTemplateTaggedHeading = syncTemplateTaggedHeading,
         syncSnapshotFlow = syncSnapshotFlow,
         clockEventSyncSnapshotFlow = clockEventSyncSnapshotFlow,

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -8,6 +8,9 @@ val desktopPackageVersion = providers.gradleProperty("desktop.version")
 
 // MSI only accepts a numeric MAJOR.MINOR.BUILD version.
 val desktopMsiPackageVersion = desktopPackageVersion.substringBefore("-")
+val desktopSmokePackage = providers.gradleProperty("desktop.smoke")
+    .map(String::toBoolean)
+    .getOrElse(false)
 
 val desktopTargetFormats = when {
     org.gradle.internal.os.OperatingSystem.current().isMacOsX -> arrayOf(TargetFormat.Dmg)
@@ -37,6 +40,7 @@ dependencies {
     implementation(compose.material3)
     implementation(project(":shared"))
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+    implementation("org.xerial:sqlite-jdbc:3.49.1.0")
     implementation("com.google.zxing:core:3.5.3")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
 
@@ -50,13 +54,25 @@ compose.desktop {
 
         nativeDistributions {
             targetFormats(*desktopTargetFormats)
-            packageName = "org-clock-desktop"
+            modules("java.sql")
+            packageName = if (desktopSmokePackage) {
+                "org-clock-desktop-smoke"
+            } else {
+                "org-clock-desktop"
+            }
             packageVersion = desktopPackageVersion
             description = "Cross-platform desktop MVP host for Org Clock."
             vendor = "shgnaka"
 
             windows {
                 msiPackageVersion = desktopMsiPackageVersion
+                if (desktopSmokePackage) {
+                    upgradeUuid = "5357c806-49d7-4c2c-b07b-c62bf85cf67a"
+                }
+                perUserInstall = true
+                menu = true
+                menuGroup = "Org Clock"
+                shortcut = true
             }
         }
     }

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
@@ -19,6 +19,9 @@ import com.example.orgclock.template.TemplateAutoGenerationRuntimeState
 import com.example.orgclock.template.TemplateAvailability
 import com.example.orgclock.template.TemplateFileStatus
 import com.example.orgclock.template.TemplateReferenceMode
+import com.example.orgclock.template.SharedTemplateStore
+import com.example.orgclock.template.TemplateSharingService
+import com.example.orgclock.template.TemplateSyncOutcome
 import com.example.orgclock.time.ClockEnvironment
 import com.example.orgclock.time.today
 import com.example.orgclock.ui.store.OrgClockStore
@@ -52,6 +55,7 @@ class DesktopAppGraph(
     private var peerTrustStore: DesktopPeerTrustStore? = null
     private var peerSyncCheckpointStore: DesktopPeerSyncCheckpointStore? = null
     private var quarantineStore: DesktopClockEventSyncQuarantineStore? = null
+    private var sharedTemplateStore: SharedTemplateStore? = null
     private var clockService: ClockService? = null
     private var remoteClockEventApplier: RemoteClockEventApplier? = null
     private var openClockScanner: DesktopOpenClockScanner? = null
@@ -189,6 +193,21 @@ class DesktopAppGraph(
         syncIdentity.pairingCode(root, pairingManager.currentInvitation(tls.certificateSha256))
     }
 
+    suspend fun syncTemplateNow(): Result<TemplateSyncOutcome> = runCatching {
+        val localRoot = currentRootPath ?: error("org root is not open")
+        val localPeerId = syncIdentity.deviceId(localRoot)
+        val peer = peerTrustStore?.listTrustRecords()
+            ?.firstOrNull { it.isActive && it.role == com.example.orgclock.sync.PeerTrustRole.Full && it.endpoint != null }
+            ?: error("No paired full-access device is available")
+        val transport = DesktopLanSyncTransport(peer.endpoint!!, peer.publicKeyBase64)
+        TemplateSharingService(
+            localStore = sharedTemplateStore ?: error("template store is unavailable"),
+            transport = transport,
+            localPeerId = localPeerId,
+            remotePeerId = peer.peerId,
+        ).synchronize().getOrThrow()
+    }
+
     fun close() {
         lanSyncServer?.close()
         lanSyncServer = null
@@ -212,6 +231,15 @@ class DesktopAppGraph(
         val trustStore = DesktopPeerTrustStore()
         val checkpointStore = DesktopPeerSyncCheckpointStore(desktopCheckpointStorePreferences(normalized))
         val quarantineStore = DesktopClockEventSyncQuarantineStore(desktopQuarantineStorePreferences(normalized))
+        val templateStore = DesktopSharedTemplateStore(
+            rootPath = normalized,
+            deviceId = syncIdentity.deviceId(normalized),
+            templatePathProvider = {
+                rootScheduleStore.load(normalized.toString()).templateFileUri
+                    ?.let(Path::of)
+                    ?: normalized.resolve(TEMPLATE_FILE_NAME)
+            },
+        )
         val fileOperationCoordinator = coordinatorFactory()
         val clockService = ClockService(
             repository,
@@ -228,6 +256,7 @@ class DesktopAppGraph(
         this.peerTrustStore = trustStore
         this.peerSyncCheckpointStore = checkpointStore
         this.quarantineStore = quarantineStore
+        this.sharedTemplateStore = templateStore
         this.clockService = clockService
         this.remoteClockEventApplier = RepositoryRemoteClockEventApplier(
             repository = repository,
@@ -244,6 +273,7 @@ class DesktopAppGraph(
                 tlsIdentity = { syncIdentity.tlsIdentity(normalized) },
                 pairingManager = pairingManager,
                 remoteEventApplier = requireNotNull(remoteClockEventApplier),
+                templateStore = { this.sharedTemplateStore },
             ).also { it.start() }
         }
         clockEventSyncSnapshotFlow.value = ClockEventStoreSnapshot(null, null, 0)

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncServer.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncServer.kt
@@ -11,6 +11,9 @@ import com.example.orgclock.sync.RemoteClockEventApplier
 import com.example.orgclock.sync.SyncPairingExchangeJsonCodec
 import com.example.orgclock.sync.SyncPairingExchangeResponse
 import com.example.orgclock.sync.SyncTransportCredentialCodec
+import com.example.orgclock.template.SharedTemplateStore
+import com.example.orgclock.template.TemplateFetchResponse
+import com.example.orgclock.template.TemplateSharingJsonCodec
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpsConfigurator
 import com.sun.net.httpserver.HttpsServer
@@ -27,6 +30,7 @@ class DesktopLanSyncServer(
     private val tlsIdentity: () -> DesktopTlsIdentity,
     private val pairingManager: DesktopPairingManager,
     private val remoteEventApplier: RemoteClockEventApplier,
+    private val templateStore: () -> SharedTemplateStore?,
 ) : AutoCloseable {
     private var server: HttpsServer? = null
 
@@ -93,6 +97,30 @@ class DesktopLanSyncServer(
                 requireSource(peer, ack.sourcePeerId)
                 requireTarget(ack.targetPeerId)
                 ClockEventTransportJsonCodec.encodeAckResult(ClockEventTransportAckResult.Accepted)
+            } }
+            createContext("/v1/template/fetch") { exchange -> handleAuthorized(exchange) { body, peer ->
+                require(peer.role == com.example.orgclock.sync.PeerTrustRole.Full) { "viewer peers cannot access templates" }
+                val request = TemplateSharingJsonCodec.decodeFetchRequest(body)
+                requireSource(peer, request.sourcePeerId)
+                requireTarget(request.targetPeerId)
+                val revision = runBlocking {
+                    (templateStore() ?: error("template store is unavailable")).readRevision().getOrThrow()
+                }
+                TemplateSharingJsonCodec.encodeFetchResponse(
+                    TemplateFetchResponse(localDeviceId(), request.sourcePeerId, revision),
+                )
+            } }
+            createContext("/v1/template/push") { exchange -> handleAuthorized(exchange) { body, peer ->
+                require(peer.role == com.example.orgclock.sync.PeerTrustRole.Full) { "viewer peers cannot update templates" }
+                val request = TemplateSharingJsonCodec.decodePushRequest(body)
+                requireSource(peer, request.sourcePeerId)
+                requireTarget(request.targetPeerId)
+                val result = runBlocking {
+                    (templateStore() ?: error("template store is unavailable"))
+                        .writeRevision(request.revision, request.expectedCurrentRevisionId)
+                        .getOrThrow()
+                }
+                TemplateSharingJsonCodec.encodePushResult(result)
             } }
             start()
         }

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncTransport.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncTransport.kt
@@ -9,6 +9,12 @@ import com.example.orgclock.sync.ClockEventTransportAck
 import com.example.orgclock.sync.ClockEventTransportAckResult
 import com.example.orgclock.sync.ClockEventTransportJsonCodec
 import com.example.orgclock.sync.SyncTransportCredentialCodec
+import com.example.orgclock.template.TemplateFetchRequest
+import com.example.orgclock.template.TemplateFetchResponse
+import com.example.orgclock.template.TemplatePushRequest
+import com.example.orgclock.template.TemplatePushResult
+import com.example.orgclock.template.TemplateSharingJsonCodec
+import com.example.orgclock.template.TemplateSyncTransport
 import java.net.URI
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -22,7 +28,7 @@ class DesktopLanSyncTransport(
     encodedCredential: String,
     private val connectTimeoutMs: Int = 5_000,
     private val readTimeoutMs: Int = 10_000,
-) : ClockEventSyncTransport {
+) : ClockEventSyncTransport, TemplateSyncTransport {
     private val endpoint = endpoint.trimEnd('/')
     private val credential = SyncTransportCredentialCodec.decode(encodedCredential).getOrThrow()
     private val sslContext = pinnedSslContext(credential.certificateSha256)
@@ -35,6 +41,16 @@ class DesktopLanSyncTransport(
 
     override suspend fun acknowledge(ack: ClockEventTransportAck): ClockEventTransportAckResult =
         ClockEventTransportJsonCodec.decodeAckResult(post("/v1/events/ack", ClockEventTransportJsonCodec.encodeAck(ack)))
+
+    override suspend fun fetchTemplate(request: TemplateFetchRequest): TemplateFetchResponse =
+        TemplateSharingJsonCodec.decodeFetchResponse(
+            post("/v1/template/fetch", TemplateSharingJsonCodec.encodeFetchRequest(request)),
+        )
+
+    override suspend fun pushTemplate(request: TemplatePushRequest): TemplatePushResult =
+        TemplateSharingJsonCodec.decodePushResult(
+            post("/v1/template/push", TemplateSharingJsonCodec.encodePushRequest(request)),
+        )
 
     private fun post(path: String, body: String): String {
         val connection = (URI.create(endpoint + path).toURL().openConnection() as HttpsURLConnection).apply {

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSharedTemplateStore.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSharedTemplateStore.kt
@@ -1,0 +1,124 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.template.SharedTemplateRevision
+import com.example.orgclock.template.SharedTemplateStore
+import com.example.orgclock.template.TemplatePushResult
+import kotlinx.datetime.Clock
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.prefs.Preferences
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class DesktopSharedTemplateStore(
+    private val rootPath: Path,
+    private val deviceId: String,
+    private val preferences: Preferences = Preferences.userRoot().node(PREFERENCES_NODE),
+    private val templatePathProvider: () -> Path = { rootPath.resolve(".orgclock-template.org") },
+) : SharedTemplateStore {
+    override suspend fun readRevision(): Result<SharedTemplateRevision?> = runCatching {
+        val templatePath = templatePath()
+        val prefix = prefix(templatePath)
+        if (!templatePath.exists()) return@runCatching null
+        val content = canonicalContent(templatePath.readText(StandardCharsets.UTF_8))
+        val contentHash = stableHash(content)
+        val storedHash = preferences.get("${prefix}content_hash", null)
+        val storedRevision = preferences.get("${prefix}revision_id", null)
+        if (storedHash == contentHash && storedRevision != null) {
+            revisionFromPreferences(prefix, content, contentHash, storedRevision)
+        } else {
+            val revisionId = "sha256:$contentHash"
+            persistMetadata(
+                prefix,
+                revisionId,
+                storedRevision,
+                contentHash,
+                Clock.System.now().toString(),
+                deviceId,
+            )
+            revisionFromPreferences(prefix, content, contentHash, revisionId)
+        }
+    }
+
+    override suspend fun writeRevision(
+        revision: SharedTemplateRevision,
+        expectedCurrentRevisionId: String?,
+    ): Result<TemplatePushResult> = runCatching {
+        val templatePath = templatePath()
+        val prefix = prefix(templatePath)
+        val current = readRevision().getOrThrow()
+        if (current?.revisionId != expectedCurrentRevisionId) {
+            return@runCatching TemplatePushResult.Conflict(current?.revisionId, revision.revisionId)
+        }
+        val content = canonicalContent(revision.content)
+        require(stableHash(content) == revision.contentHash) { "Template content hash mismatch" }
+        templatePath.writeText(content, StandardCharsets.UTF_8)
+        persistMetadata(
+            prefix,
+            revision.revisionId,
+            revision.parentRevisionId,
+            revision.contentHash,
+            revision.updatedAt.toString(),
+            revision.updatedByDeviceId,
+        )
+        TemplatePushResult.Accepted(revision.revisionId)
+    }
+
+    private fun templatePath(): Path {
+        val path = templatePathProvider().toAbsolutePath().normalize()
+        require(path.startsWith(rootPath.toAbsolutePath().normalize())) {
+            "Shared template must be inside the org root"
+        }
+        return path
+    }
+
+    private fun revisionFromPreferences(
+        prefix: String,
+        content: String,
+        contentHash: String,
+        revisionId: String,
+    ) = SharedTemplateRevision(
+        revisionId = revisionId,
+        parentRevisionId = preferences.get("${prefix}parent_revision_id", null),
+        content = content,
+        contentHash = contentHash,
+        updatedAt = kotlinx.datetime.Instant.parse(
+            preferences.get("${prefix}updated_at", Clock.System.now().toString()),
+        ),
+        updatedByDeviceId = preferences.get("${prefix}updated_by", deviceId),
+    )
+
+    private fun persistMetadata(
+        prefix: String,
+        revisionId: String,
+        parentRevisionId: String?,
+        contentHash: String,
+        updatedAt: String,
+        updatedBy: String,
+    ) {
+        preferences.put("${prefix}revision_id", revisionId)
+        parentRevisionId?.let { preferences.put("${prefix}parent_revision_id", it) }
+            ?: preferences.remove("${prefix}parent_revision_id")
+        preferences.put("${prefix}content_hash", contentHash)
+        preferences.put("${prefix}updated_at", updatedAt)
+        preferences.put("${prefix}updated_by", updatedBy)
+        preferences.flush()
+    }
+
+    private fun stableHash(value: String): String =
+        MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
+    private fun canonicalContent(value: String): String =
+        value.replace("\r\n", "\n").removeSuffix("\n")
+
+    private fun prefix(templatePath: Path): String =
+        "tpl_${stableHash(templatePath.toAbsolutePath().normalize().toString()).take(PREFERENCE_HASH_CHARS)}_"
+
+    private companion object {
+        const val PREFERENCES_NODE = "com/example/orgclock/desktop/template_sharing"
+        const val PREFERENCE_HASH_CHARS = 16
+    }
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommand.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommand.kt
@@ -1,0 +1,148 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.data.DesktopFileOrgRepository
+import com.example.orgclock.domain.ClockService
+import com.example.orgclock.model.HeadingPath
+import com.example.orgclock.sync.JdbcClockEventStore
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+internal object DesktopSmokeTestCommand {
+    private const val FLAG = "--smoke-test"
+
+    fun isRequested(args: Array<String>): Boolean = FLAG in args
+
+    fun run(args: Array<String>) {
+        val options = parseOptions(args)
+        val root = Path.of(options.getValue("--root")).absolute().normalize().createDirectories()
+        val report = options["--report"]?.let { Path.of(it).absolute().normalize() }
+        val checks = mutableListOf<SmokeCheck>()
+
+        val exitCode = runCatching {
+            runBlocking {
+                prepareFixture(root)
+                checks += check("sqlite_event_store") {
+                    JdbcClockEventStore.create(root.resolve(".orgclock/clock-events.db")).readSnapshot()
+                    require(root.resolve(".orgclock/clock-events.db").exists()) { "SQLite database was not created" }
+                }
+                checks += check("org_file_read") {
+                    val files = DesktopFileOrgRepository(root).listOrgFiles().getOrThrow()
+                    require(files.any { it.displayName == "2026-01-02.org" }) { "Smoke org file was not listed" }
+                }
+                checks += check("clock_start_stop") {
+                    val repository = DesktopFileOrgRepository(root)
+                    val service = ClockService(repository)
+                    val file = repository.listOrgFiles().getOrThrow().first { it.displayName == "2026-01-02.org" }
+                    val heading = HeadingPath(listOf("Smoke", "Packaged runtime"))
+                    service.startClockInFile(
+                        fileId = file.fileId,
+                        headingPath = heading,
+                        now = Instant.parse("2026-01-02T09:00:00Z"),
+                        timeZone = TimeZone.UTC,
+                    ).getOrThrow()
+                    service.stopClockInFile(
+                        fileId = file.fileId,
+                        headingPath = heading,
+                        now = Instant.parse("2026-01-02T10:00:00Z"),
+                        timeZone = TimeZone.UTC,
+                    ).getOrThrow()
+                    require(root.resolve("2026-01-02.org").readText().contains("CLOCK:")) {
+                        "Clock history was not written"
+                    }
+                }
+                checks += check("template_read") {
+                    val template = root.resolve(".orgclock-template.org")
+                    require(template.exists()) { "Template fixture is missing" }
+                    require(template.readText().contains("Packaged runtime")) { "Template contents were not readable" }
+                }
+            }
+        }.fold(
+            onSuccess = { 0 },
+            onFailure = { error ->
+                checks += SmokeCheck("smoke_runner", false, error.stackTraceToString())
+                1
+            },
+        )
+
+        val json = reportJson(root, checks)
+        if (report != null) {
+            report.parent?.createDirectories()
+            report.writeText(json, StandardCharsets.UTF_8)
+        }
+        println(json)
+        if (exitCode != 0 || checks.any { !it.passed }) {
+            throw IllegalStateException("Desktop smoke test failed")
+        }
+    }
+
+    private fun parseOptions(args: Array<String>): Map<String, String> {
+        val values = mutableMapOf<String, String>()
+        var index = 0
+        while (index < args.size) {
+            val arg = args[index]
+            if (arg == "--root" || arg == "--report") {
+                require(index + 1 < args.size) { "Missing value for $arg" }
+                values[arg] = args[index + 1]
+                index += 2
+            } else {
+                index += 1
+            }
+        }
+        require(values["--root"].isNullOrBlank().not()) { "--root is required for --smoke-test" }
+        return values
+    }
+
+    private fun prepareFixture(root: Path) {
+        root.resolve("2026-01-02.org").writeText(
+            "* Smoke\n** Packaged runtime\n",
+            StandardCharsets.UTF_8,
+        )
+        root.resolve(".orgclock-template.org").writeText(
+            "* Smoke\n** Packaged runtime\n",
+            StandardCharsets.UTF_8,
+        )
+    }
+
+    private suspend fun check(name: String, block: suspend () -> Unit): SmokeCheck =
+        runCatching { block() }.fold(
+            onSuccess = { SmokeCheck(name, true, null) },
+            onFailure = { SmokeCheck(name, false, it.stackTraceToString()) },
+        )
+
+    private fun reportJson(root: Path, checks: List<SmokeCheck>): String = buildString {
+        append("{\n")
+        append("  \"passed\": ${checks.all { it.passed }},\n")
+        append("  \"root\": \"${escape(root.toString())}\",\n")
+        append("  \"checks\": [\n")
+        checks.forEachIndexed { index, check ->
+            append("    {\"name\":\"${escape(check.name)}\",\"passed\":${check.passed}")
+            check.detail?.let { append(",\"detail\":\"${escape(it)}\"") }
+            append("}")
+            if (index != checks.lastIndex) append(",")
+            append("\n")
+        }
+        append("  ]\n")
+        append("}")
+    }
+
+    private fun escape(value: String): String = value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+
+    private data class SmokeCheck(
+        val name: String,
+        val passed: Boolean,
+        val detail: String?,
+    )
+}

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
@@ -81,7 +81,15 @@ import kotlinx.datetime.toLocalDateTime
 import java.io.File
 import javax.swing.JFileChooser
 
-fun main() = application {
+fun main(args: Array<String>) {
+    if (DesktopSmokeTestCommand.isRequested(args)) {
+        DesktopSmokeTestCommand.run(args)
+        return
+    }
+    launchDesktopApplication()
+}
+
+private fun launchDesktopApplication() = application {
     Window(
         onCloseRequest = ::exitApplication,
         title = "Org Clock Desktop",

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
@@ -66,6 +66,7 @@ import com.example.orgclock.ui.state.OrgDivergenceRecommendedAction
 import com.example.orgclock.ui.state.OrgDivergenceSeverity
 import com.example.orgclock.template.TemplateAvailability
 import com.example.orgclock.template.TemplateReferenceMode
+import com.example.orgclock.template.TemplateSyncOutcome
 import com.example.orgclock.ui.state.ClockEditDraft
 import com.example.orgclock.ui.state.CreateHeadingDialogState
 import com.example.orgclock.ui.state.CreateHeadingMode
@@ -97,6 +98,8 @@ private fun DesktopApp() {
     val runtime = remember(graph) { graph.desktopEventSyncRuntime() }
     val state by store.uiState.collectAsState()
     val syncState by runtime.state.collectAsState()
+    var templateSyncMessage by remember { mutableStateOf<String?>(null) }
+    var templateSyncInProgress by remember { mutableStateOf(false) }
 
     LaunchedEffect(store) {
         store.onAction(OrgClockUiAction.Initialize)
@@ -136,6 +139,26 @@ private fun DesktopApp() {
                     state = state,
                     syncState = syncState,
                     syncPairingCode = graph.currentSyncPairingCode(),
+                    templateSyncMessage = templateSyncMessage,
+                    templateSyncInProgress = templateSyncInProgress,
+                    onSyncTemplate = {
+                        scope.launch {
+                            templateSyncInProgress = true
+                            templateSyncMessage = graph.syncTemplateNow().fold(
+                                onSuccess = { outcome ->
+                                    when (outcome) {
+                                        TemplateSyncOutcome.AlreadyCurrent -> "Template is already synchronized."
+                                        is TemplateSyncOutcome.Downloaded -> "Template downloaded from the paired device."
+                                        is TemplateSyncOutcome.Uploaded -> "Template uploaded to the paired device."
+                                        is TemplateSyncOutcome.Conflict -> "Template conflict detected. Neither version was overwritten."
+                                    }
+                                },
+                                onFailure = { it.message ?: "Template sync failed." },
+                            )
+                            templateSyncInProgress = false
+                            store.onAction(OrgClockUiAction.RefreshTemplateStatus)
+                        }
+                    },
                     onPickRoot = {
                         chooseRootDirectory(state.rootReference)?.let { root ->
                             store.onAction(OrgClockUiAction.PickRoot(root))
@@ -158,6 +181,9 @@ private fun DesktopHostCard(
     state: OrgClockUiState,
     syncState: DesktopEventSyncRuntimeState,
     syncPairingCode: String?,
+    templateSyncMessage: String?,
+    templateSyncInProgress: Boolean,
+    onSyncTemplate: () -> Unit,
     onPickRoot: () -> Unit,
     onAction: (OrgClockUiAction) -> Unit,
     onSyncNow: () -> Unit,
@@ -214,6 +240,9 @@ private fun DesktopHostCard(
                     state = state,
                     syncState = syncState,
                     syncPairingCode = syncPairingCode,
+                    templateSyncMessage = templateSyncMessage,
+                    templateSyncInProgress = templateSyncInProgress,
+                    onSyncTemplate = onSyncTemplate,
                     onChangeRoot = onPickRoot,
                     onBack = { onAction(OrgClockUiAction.BackFromSettings) },
                     onReloadFiles = { onAction(OrgClockUiAction.RefreshFiles) },
@@ -269,6 +298,11 @@ private fun RootSetupPane(onPickRoot: () -> Unit) {
         Button(onClick = onPickRoot) {
             Text("Select local directory")
         }
+        Text(
+            text = "After selecting a root, use its template or synchronize one from a paired device in Settings.",
+            style = MaterialTheme.typography.bodySmall,
+            color = Color(0xFFD3E6D6),
+        )
     }
 }
 
@@ -529,6 +563,9 @@ private fun SettingsPane(
     state: OrgClockUiState,
     syncState: DesktopEventSyncRuntimeState,
     syncPairingCode: String?,
+    templateSyncMessage: String?,
+    templateSyncInProgress: Boolean,
+    onSyncTemplate: () -> Unit,
     onChangeRoot: () -> Unit,
     onBack: () -> Unit,
     onReloadFiles: () -> Unit,
@@ -549,6 +586,9 @@ private fun SettingsPane(
         TemplateSettingsCard(
             state = state,
             onAction = onAction,
+            syncMessage = templateSyncMessage,
+            syncInProgress = templateSyncInProgress,
+            onSyncTemplate = onSyncTemplate,
         )
         DesktopSyncSettingsCard(
             state = syncState,
@@ -737,6 +777,9 @@ private fun OrgRootSettingsCard(
 private fun TemplateSettingsCard(
     state: OrgClockUiState,
     onAction: (OrgClockUiAction) -> Unit,
+    syncMessage: String?,
+    syncInProgress: Boolean,
+    onSyncTemplate: () -> Unit,
 ) {
     val status = state.templateFileStatus
     val source = when (status.referenceMode) {
@@ -778,6 +821,9 @@ private fun TemplateSettingsCard(
         }
         SettingsMessageBlock(text = message, tone = tone)
         SettingsActionRow {
+            Button(onClick = onSyncTemplate, enabled = !syncInProgress) {
+                Text(if (syncInProgress) "Synchronizing..." else "Sync with paired device")
+            }
             Button(
                 onClick = { onAction(OrgClockUiAction.OpenTemplateFilePicker) },
                 enabled = state.rootReference != null,
@@ -800,6 +846,16 @@ private fun TemplateSettingsCard(
                     Text("Create default template file")
                 }
             }
+        }
+        syncMessage?.let {
+            SettingsMessageBlock(
+                text = it,
+                tone = if (it.contains("failed", ignoreCase = true) || it.contains("conflict", ignoreCase = true)) {
+                    SettingsMessageTone.Warning
+                } else {
+                    SettingsMessageTone.Success
+                },
+            )
         }
     }
 }

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSharedTemplateStoreTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSharedTemplateStoreTest.kt
@@ -1,0 +1,76 @@
+package com.example.orgclock.desktop
+
+import com.example.orgclock.template.SharedTemplateRevision
+import com.example.orgclock.template.TemplatePushResult
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.prefs.Preferences
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DesktopSharedTemplateStoreTest {
+    private val roots = mutableListOf<Path>()
+    private val nodes = mutableListOf<Preferences>()
+
+    @AfterTest
+    fun cleanup() {
+        roots.forEach { root ->
+            Files.walk(root).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+            }
+        }
+        nodes.forEach { runCatching { it.removeNode() } }
+    }
+
+    @Test
+    fun externalEdit_becomesChildOfPreviouslyObservedRevision() = runTest {
+        val root = createTempDirectory("template-store").also(roots::add)
+        val node = testNode()
+        root.resolve(".orgclock-template.org").writeText("* First\n")
+        val store = DesktopSharedTemplateStore(root, "desktop-a", node)
+        val first = store.readRevision().getOrThrow()!!
+
+        root.resolve(".orgclock-template.org").writeText("* Second\n")
+        val second = store.readRevision().getOrThrow()!!
+
+        assertEquals(first.revisionId, second.parentRevisionId)
+    }
+
+    @Test
+    fun writeRevision_rejectsStaleExpectedRevision() = runTest {
+        val root = createTempDirectory("template-store").also(roots::add)
+        val node = testNode()
+        root.resolve(".orgclock-template.org").writeText("* Local\n")
+        val store = DesktopSharedTemplateStore(root, "desktop-a", node)
+        val current = store.readRevision().getOrThrow()!!
+        val incoming = SharedTemplateRevision(
+            revisionId = "remote",
+            parentRevisionId = null,
+            content = "* Remote",
+            contentHash = sha256("* Remote"),
+            updatedAt = Instant.parse("2026-06-12T00:00:00Z"),
+            updatedByDeviceId = "android-a",
+        )
+
+        val result = store.writeRevision(incoming, "wrong").getOrThrow()
+
+        assertIs<TemplatePushResult.Conflict>(result)
+        assertEquals("* Local\n", root.resolve(".orgclock-template.org").readText())
+        assertEquals(current.revisionId, store.readRevision().getOrThrow()!!.revisionId)
+    }
+
+    private fun testNode(): Preferences =
+        Preferences.userRoot().node("com/example/orgclock/desktop/template-test/${System.nanoTime()}")
+            .also(nodes::add)
+
+    private fun sha256(value: String): String =
+        java.security.MessageDigest.getInstance("SHA-256").digest(value.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+}

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommandTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommandTest.kt
@@ -1,0 +1,45 @@
+package com.example.orgclock.desktop
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DesktopSmokeTestCommandTest {
+    private val roots = mutableListOf<Path>()
+
+    @AfterTest
+    fun cleanup() {
+        roots.forEach { root ->
+            Files.walk(root).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+            }
+        }
+    }
+
+    @Test
+    fun smokeCommand_createsPassingReportAndRuntimeArtifacts() {
+        val root = createTempDirectory("desktop-smoke-command").also(roots::add)
+        val report = root.resolve("report.json")
+
+        DesktopSmokeTestCommand.run(
+            arrayOf(
+                "--smoke-test",
+                "--root",
+                root.resolve("org root 日本語").toString(),
+                "--report",
+                report.toString(),
+            ),
+        )
+
+        val orgRoot = root.resolve("org root 日本語")
+        assertTrue(report.exists())
+        assertTrue(report.readText().contains("\"passed\": true"))
+        assertTrue(orgRoot.resolve(".orgclock/clock-events.db").exists())
+        assertTrue(orgRoot.resolve("2026-01-02.org").readText().contains("CLOCK:"))
+    }
+}

--- a/docs/desktop-manual-smoke-test.md
+++ b/docs/desktop-manual-smoke-test.md
@@ -30,6 +30,29 @@ Desktop MVP は Windows / Linux の起動・配布・基本操作確認を対象
 - Windows 環境では `.msi` が確認できる
 - Linux 環境では `.deb` またはportable `.tar.gz` が確認できる
 
+Windowsでは、MSIのインストール、配布exe内のSQLite、org読み書き、clock操作、
+テンプレート読込、ショートカット、アンインストールを自動確認できます。
+
+```powershell
+.\scripts\desktop-smoke-test.ps1
+```
+
+スクリプトは既存のリリース版と修復・更新処理が衝突しないよう、
+スモーク専用の一時的なMSIバージョンを自動採番する。
+
+既にMSIを生成済みの場合:
+
+```powershell
+.\scripts\desktop-smoke-test.ps1 -SkipBuild
+```
+
+既存の管理者インストールや端末ポリシーによりMSIのサイレントインストールが
+できない開発端末では、配布ランタイム部分だけを検査できます。
+
+```powershell
+.\scripts\desktop-smoke-test.ps1 -RuntimeOnly
+```
+
 ## 4. GitHub Release install path
 1. `vX.Y.Z` tag build completes in `Release Desktop Installers`
 2. GitHub Release Assets contains Windows `.msi` and Linux `.deb` / portable `.tar.gz`

--- a/docs/template-sharing.md
+++ b/docs/template-sharing.md
@@ -1,0 +1,39 @@
+# Template Sharing
+
+Org Clockのテンプレート共有はclock event logとは独立した資産同期として扱う。
+
+## Source of truth
+
+- 各端末はテンプレート本文をローカルのorgテンプレートへ保存する
+- Desktopは`.orgclock-template.org`を使用する
+- Androidはroot設定で選択されたSAFテンプレートを使用する
+- ファイルパスやSAF URIは端末間で共有しない
+- revision ID、親revision、本文hash、更新端末を交換する
+
+## Synchronization
+
+既存のTLS LAN transportとペアリングcredentialを使用する。
+
+- `POST /v1/template/fetch`
+- `POST /v1/template/push`
+- Full peerのみ利用可能
+- Viewer peerはテンプレートを取得・更新できない
+
+同期規則:
+
+1. 一方にだけテンプレートがあれば、存在する側から共有する
+2. 同じrevisionなら変更しない
+3. 一方が他方の直接の子revisionならfast-forwardする
+4. 両方が異なるrevisionへ分岐した場合は競合とし、どちらも上書きしない
+
+## User flow
+
+- root選択画面で、選択後に既存テンプレートまたはペア端末のテンプレートを利用できることを案内する
+- root選択後、Settingsの`Sync with paired device`から同期する
+- 同期にはFull roleのペア端末が必要
+- 競合時は自動マージせず、どちらも維持する
+
+## Generated daily files
+
+テンプレート同期は既存の日次orgファイルを書き換えない。
+同期後のテンプレートは、以後の日次ファイル生成に使用する。

--- a/scripts/desktop-smoke-test.ps1
+++ b/scripts/desktop-smoke-test.ps1
@@ -1,0 +1,114 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipBuild,
+    [switch]$RuntimeOnly,
+    [switch]$KeepInstalled,
+    [string]$SmokePackageVersion,
+    [string]$ArtifactsDirectory = "artifacts/desktop-smoke"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$artifacts = Join-Path $repoRoot $ArtifactsDirectory
+$smokeRoot = Join-Path $artifacts "org-root-日本語"
+$report = Join-Path $artifacts "smoke-report.json"
+$msiLog = Join-Path $artifacts "msi-install.log"
+
+New-Item -ItemType Directory -Force $artifacts, $smokeRoot | Out-Null
+
+if (-not $SkipBuild) {
+    $packageTask = if ($RuntimeOnly) { ":desktopApp:createDistributable" } else { ":desktopApp:packageMsi" }
+    if (-not $SmokePackageVersion) {
+        $buildNumber = [int]((Get-Date).ToUniversalTime().Ticks % 60000) + 1
+        $SmokePackageVersion = "0.0.$buildNumber"
+    }
+    & (Join-Path $repoRoot "gradlew.bat") $packageTask "-Pdesktop.version=$SmokePackageVersion" "-Pdesktop.smoke=true"
+    if ($LASTEXITCODE -ne 0) { throw "Desktop package build failed with exit code $LASTEXITCODE" }
+}
+
+$runtimeExe = Get-ChildItem (Join-Path $repoRoot "desktopApp/build/compose/binaries/main/app") -Recurse -Filter "org-clock-desktop-smoke.exe" -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty FullName -First 1
+if ($RuntimeOnly) {
+    if (-not $runtimeExe) { throw "Distributable executable was not found. Run without -SkipBuild first." }
+    $runtimeSmoke = Start-Process $runtimeExe -ArgumentList @(
+        "--smoke-test", "--root", "`"$smokeRoot`"", "--report", "`"$report`""
+    ) -Wait -PassThru
+    if ($runtimeSmoke.ExitCode -ne 0) {
+        throw "Distributable executable smoke test failed with exit code $($runtimeSmoke.ExitCode)"
+    }
+    $result = Get-Content $report -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not $result.passed) { throw "Smoke report contains failed checks: $report" }
+    Write-Host "Desktop distributable smoke test passed."
+    Write-Host "Executable: $runtimeExe"
+    Write-Host "Report: $report"
+    exit 0
+}
+
+$msi = Get-ChildItem (Join-Path $repoRoot "desktopApp/build/compose/binaries/main") -Recurse -Filter *.msi |
+    Sort-Object LastWriteTimeUtc -Descending |
+    Select-Object -First 1
+if (-not $msi) { throw "No MSI was found. Run without -SkipBuild first." }
+
+$installedBySmoke = $false
+try {
+    $install = Start-Process msiexec.exe -ArgumentList @(
+        "/i", "`"$($msi.FullName)`"", "/qn", "/norestart", "/l*v", "`"$msiLog`""
+    ) -Wait -PassThru
+    if ($install.ExitCode -ne 0) {
+        if ($install.ExitCode -eq 1625) {
+            throw "MSI installation was blocked by Windows policy or an existing managed installation. Use -RuntimeOnly for the packaged-runtime checks. See $msiLog"
+        }
+        throw "MSI installation failed with exit code $($install.ExitCode). See $msiLog"
+    }
+    $installedBySmoke = $true
+
+    $exeCandidates = @(
+        (Join-Path $env:LOCALAPPDATA "Programs\org-clock-desktop-smoke\org-clock-desktop-smoke.exe"),
+        (Join-Path $env:LOCALAPPDATA "org-clock-desktop-smoke\org-clock-desktop-smoke.exe"),
+        (Join-Path $env:ProgramFiles "org-clock-desktop-smoke\org-clock-desktop-smoke.exe")
+    )
+    if (${env:ProgramFiles(x86)}) {
+        $exeCandidates += Join-Path ${env:ProgramFiles(x86)} "org-clock-desktop-smoke\org-clock-desktop-smoke.exe"
+    }
+    $exe = $exeCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (-not $exe) {
+        $exe = Get-ChildItem @($env:LOCALAPPDATA, $env:ProgramFiles) -Recurse -Filter "org-clock-desktop-smoke.exe" -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName -First 1
+    }
+    if (-not $exe) { throw "Installed org-clock-desktop-smoke.exe was not found" }
+
+    $startMenuShortcut = Get-ChildItem @(
+        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"),
+        (Join-Path $env:ProgramData "Microsoft\Windows\Start Menu\Programs")
+    ) -Recurse -Filter "*org*clock*.lnk" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $startMenuShortcut) { throw "Start menu shortcut was not created" }
+
+    $desktopShortcut = Get-ChildItem @(
+        [Environment]::GetFolderPath("Desktop"),
+        [Environment]::GetFolderPath("CommonDesktopDirectory")
+    ) -Filter "*org*clock*.lnk" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $desktopShortcut) { throw "Desktop shortcut was not created" }
+
+    $installedSmoke = Start-Process $exe -ArgumentList @(
+        "--smoke-test", "--root", "`"$smokeRoot`"", "--report", "`"$report`""
+    ) -Wait -PassThru
+    if ($installedSmoke.ExitCode -ne 0) {
+        throw "Packaged executable smoke test failed with exit code $($installedSmoke.ExitCode)"
+    }
+    $result = Get-Content $report -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not $result.passed) { throw "Smoke report contains failed checks: $report" }
+
+    Write-Host "Desktop MSI smoke test passed."
+    Write-Host "MSI: $($msi.FullName)"
+    Write-Host "Report: $report"
+}
+finally {
+    if (-not $KeepInstalled -and $installedBySmoke) {
+        $uninstall = Start-Process msiexec.exe -ArgumentList @(
+            "/x", "`"$($msi.FullName)`"", "/qn", "/norestart"
+        ) -Wait -PassThru
+        if ($uninstall.ExitCode -ne 0) {
+            Write-Warning "MSI uninstall failed with exit code $($uninstall.ExitCode)"
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/orgclock/template/TemplateSharingContracts.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/template/TemplateSharingContracts.kt
@@ -1,0 +1,62 @@
+package com.example.orgclock.template
+
+import kotlinx.datetime.Instant
+
+const val TEMPLATE_SHARING_SCHEMA_V1 = "orgclock.template.v1"
+
+data class SharedTemplateRevision(
+    val schema: String = TEMPLATE_SHARING_SCHEMA_V1,
+    val revisionId: String,
+    val parentRevisionId: String?,
+    val content: String,
+    val contentHash: String,
+    val updatedAt: Instant,
+    val updatedByDeviceId: String,
+) {
+    init {
+        require(schema == TEMPLATE_SHARING_SCHEMA_V1) { "Unsupported template schema: $schema" }
+        require(revisionId.isNotBlank()) { "Template revision ID cannot be blank." }
+        require(contentHash.isNotBlank()) { "Template content hash cannot be blank." }
+        require(updatedByDeviceId.isNotBlank()) { "Template updater device ID cannot be blank." }
+    }
+}
+
+data class TemplateFetchRequest(
+    val sourcePeerId: String,
+    val targetPeerId: String,
+)
+
+data class TemplateFetchResponse(
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val revision: SharedTemplateRevision?,
+)
+
+data class TemplatePushRequest(
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val revision: SharedTemplateRevision,
+    val expectedCurrentRevisionId: String?,
+)
+
+sealed interface TemplatePushResult {
+    data class Accepted(val revisionId: String) : TemplatePushResult
+    data class Conflict(
+        val currentRevisionId: String?,
+        val incomingRevisionId: String,
+    ) : TemplatePushResult
+}
+
+interface TemplateSyncTransport {
+    suspend fun fetchTemplate(request: TemplateFetchRequest): TemplateFetchResponse
+    suspend fun pushTemplate(request: TemplatePushRequest): TemplatePushResult
+}
+
+interface SharedTemplateStore {
+    suspend fun readRevision(): Result<SharedTemplateRevision?>
+
+    suspend fun writeRevision(
+        revision: SharedTemplateRevision,
+        expectedCurrentRevisionId: String?,
+    ): Result<TemplatePushResult>
+}

--- a/shared/src/commonMain/kotlin/com/example/orgclock/template/TemplateSharingJsonCodec.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/template/TemplateSharingJsonCodec.kt
@@ -1,0 +1,127 @@
+package com.example.orgclock.template
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+object TemplateSharingJsonCodec {
+    fun encodeFetchRequest(value: TemplateFetchRequest): String =
+        json.encodeToString(FetchRequestWire.serializer(), FetchRequestWire(value.sourcePeerId, value.targetPeerId))
+
+    fun decodeFetchRequest(raw: String): TemplateFetchRequest =
+        json.decodeFromString(FetchRequestWire.serializer(), raw).let {
+            TemplateFetchRequest(it.sourcePeerId, it.targetPeerId)
+        }
+
+    fun encodeFetchResponse(value: TemplateFetchResponse): String =
+        json.encodeToString(
+            FetchResponseWire.serializer(),
+            FetchResponseWire(value.sourcePeerId, value.targetPeerId, value.revision?.toWire()),
+        )
+
+    fun decodeFetchResponse(raw: String): TemplateFetchResponse =
+        json.decodeFromString(FetchResponseWire.serializer(), raw).let {
+            TemplateFetchResponse(it.sourcePeerId, it.targetPeerId, it.revision?.toModel())
+        }
+
+    fun encodePushRequest(value: TemplatePushRequest): String =
+        json.encodeToString(
+            PushRequestWire.serializer(),
+            PushRequestWire(
+                value.sourcePeerId,
+                value.targetPeerId,
+                value.revision.toWire(),
+                value.expectedCurrentRevisionId,
+            ),
+        )
+
+    fun decodePushRequest(raw: String): TemplatePushRequest =
+        json.decodeFromString(PushRequestWire.serializer(), raw).let {
+            TemplatePushRequest(
+                it.sourcePeerId,
+                it.targetPeerId,
+                it.revision.toModel(),
+                it.expectedCurrentRevisionId,
+            )
+        }
+
+    fun encodePushResult(value: TemplatePushResult): String =
+        json.encodeToString(
+            PushResultWire.serializer(),
+            when (value) {
+                is TemplatePushResult.Accepted -> PushResultWire(true, value.revisionId)
+                is TemplatePushResult.Conflict -> PushResultWire(
+                    accepted = false,
+                    revisionId = value.incomingRevisionId,
+                    currentRevisionId = value.currentRevisionId,
+                )
+            },
+        )
+
+    fun decodePushResult(raw: String): TemplatePushResult =
+        json.decodeFromString(PushResultWire.serializer(), raw).let {
+            if (it.accepted) {
+                TemplatePushResult.Accepted(it.revisionId)
+            } else {
+                TemplatePushResult.Conflict(it.currentRevisionId, it.revisionId)
+            }
+        }
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+}
+
+@Serializable
+private data class FetchRequestWire(val sourcePeerId: String, val targetPeerId: String)
+
+@Serializable
+private data class FetchResponseWire(
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val revision: RevisionWire? = null,
+)
+
+@Serializable
+private data class PushRequestWire(
+    val sourcePeerId: String,
+    val targetPeerId: String,
+    val revision: RevisionWire,
+    val expectedCurrentRevisionId: String? = null,
+)
+
+@Serializable
+private data class PushResultWire(
+    val accepted: Boolean,
+    val revisionId: String,
+    val currentRevisionId: String? = null,
+)
+
+@Serializable
+private data class RevisionWire(
+    val schema: String,
+    val revisionId: String,
+    val parentRevisionId: String? = null,
+    val content: String,
+    val contentHash: String,
+    val updatedAt: String,
+    val updatedByDeviceId: String,
+)
+
+private fun SharedTemplateRevision.toWire() = RevisionWire(
+    schema,
+    revisionId,
+    parentRevisionId,
+    content,
+    contentHash,
+    updatedAt.toString(),
+    updatedByDeviceId,
+)
+
+private fun RevisionWire.toModel() = SharedTemplateRevision(
+    schema,
+    revisionId,
+    parentRevisionId,
+    content,
+    contentHash,
+    Instant.parse(updatedAt),
+    updatedByDeviceId,
+)

--- a/shared/src/commonMain/kotlin/com/example/orgclock/template/TemplateSharingService.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/template/TemplateSharingService.kt
@@ -1,0 +1,73 @@
+package com.example.orgclock.template
+
+sealed interface TemplateSyncOutcome {
+    data object AlreadyCurrent : TemplateSyncOutcome
+    data class Downloaded(val revisionId: String) : TemplateSyncOutcome
+    data class Uploaded(val revisionId: String) : TemplateSyncOutcome
+    data class Conflict(
+        val localRevisionId: String?,
+        val remoteRevisionId: String?,
+    ) : TemplateSyncOutcome
+}
+
+class TemplateSharingService(
+    private val localStore: SharedTemplateStore,
+    private val transport: TemplateSyncTransport,
+    private val localPeerId: String,
+    private val remotePeerId: String,
+) {
+    suspend fun synchronize(): Result<TemplateSyncOutcome> = runCatching {
+        val local = localStore.readRevision().getOrThrow()
+        val remote = transport.fetchTemplate(
+            TemplateFetchRequest(localPeerId, remotePeerId),
+        ).revision
+
+        when {
+            local == null && remote == null -> TemplateSyncOutcome.AlreadyCurrent
+            local == null && remote != null -> {
+                when (localStore.writeRevision(remote, expectedCurrentRevisionId = null).getOrThrow()) {
+                    is TemplatePushResult.Accepted -> TemplateSyncOutcome.Downloaded(remote.revisionId)
+                    is TemplatePushResult.Conflict -> TemplateSyncOutcome.Conflict(null, remote.revisionId)
+                }
+            }
+            local != null && remote == null -> {
+                when (
+                    transport.pushTemplate(
+                        TemplatePushRequest(localPeerId, remotePeerId, local, expectedCurrentRevisionId = null),
+                    )
+                ) {
+                    is TemplatePushResult.Accepted -> TemplateSyncOutcome.Uploaded(local.revisionId)
+                    is TemplatePushResult.Conflict -> TemplateSyncOutcome.Conflict(local.revisionId, null)
+                }
+            }
+            local!!.revisionId == remote!!.revisionId -> TemplateSyncOutcome.AlreadyCurrent
+            local.parentRevisionId == remote.revisionId -> {
+                when (
+                    transport.pushTemplate(
+                        TemplatePushRequest(
+                            localPeerId,
+                            remotePeerId,
+                            local,
+                            expectedCurrentRevisionId = remote.revisionId,
+                        ),
+                    )
+                ) {
+                    is TemplatePushResult.Accepted -> TemplateSyncOutcome.Uploaded(local.revisionId)
+                    is TemplatePushResult.Conflict -> TemplateSyncOutcome.Conflict(local.revisionId, remote.revisionId)
+                }
+            }
+            remote.parentRevisionId == local.revisionId -> {
+                when (
+                    localStore.writeRevision(
+                        remote,
+                        expectedCurrentRevisionId = local.revisionId,
+                    ).getOrThrow()
+                ) {
+                    is TemplatePushResult.Accepted -> TemplateSyncOutcome.Downloaded(remote.revisionId)
+                    is TemplatePushResult.Conflict -> TemplateSyncOutcome.Conflict(local.revisionId, remote.revisionId)
+                }
+            }
+            else -> TemplateSyncOutcome.Conflict(local.revisionId, remote.revisionId)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiAction.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiAction.kt
@@ -50,6 +50,7 @@ sealed interface OrgClockUiAction {
     data object ClearExplicitTemplateFile : OrgClockUiAction
     data class SelectTemplateFile(val file: OrgFileEntry) : OrgClockUiAction
     data object CreateDefaultTemplateFile : OrgClockUiAction
+    data object SyncTemplateNow : OrgClockUiAction
     data class ToggleNotificationEnabled(val enabled: Boolean) : OrgClockUiAction
     data class ChangeNotificationDisplayMode(val mode: NotificationDisplayMode) : OrgClockUiAction
     data object RequestNotificationPermissionHandled : OrgClockUiAction

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiState.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/state/OrgClockUiState.kt
@@ -99,6 +99,8 @@ data class OrgClockUiState(
     val autoGenerationRuntimeState: TemplateAutoGenerationRuntimeState = TemplateAutoGenerationRuntimeState(),
     val templateCandidateFiles: List<OrgFileEntry> = emptyList(),
     val selectingTemplateFile: Boolean = false,
+    val templateSyncInProgress: Boolean = false,
+    val templateSyncMessage: String? = null,
     val showPerfOverlay: Boolean = false,
     val syncFeatureVisible: Boolean = false,
     val syncDebugVisible: Boolean = false,

--- a/shared/src/commonMain/kotlin/com/example/orgclock/ui/store/OrgClockStore.kt
+++ b/shared/src/commonMain/kotlin/com/example/orgclock/ui/store/OrgClockStore.kt
@@ -29,6 +29,7 @@ import com.example.orgclock.template.ScheduleWeekday
 import com.example.orgclock.template.TemplateAutoGenerationRuntimeState
 import com.example.orgclock.template.TemplateFileStatus
 import com.example.orgclock.template.TemplateReferenceMode
+import com.example.orgclock.template.TemplateSyncOutcome
 import com.example.orgclock.ui.state.ClockEditDraft
 import com.example.orgclock.ui.state.CreateHeadingDialogState
 import com.example.orgclock.ui.state.CreateHeadingMode
@@ -90,6 +91,9 @@ class OrgClockStore(
     private val syncRootScheduleConfig: suspend (RootScheduleConfig) -> Unit,
     private val runAutoGenerationCatchUp: suspend (RootReference) -> Unit,
     private val createDefaultTemplateFileAction: suspend (RootReference) -> Result<String> = { Result.failure(UnsupportedOperationException("template file creation unavailable")) },
+    private val syncTemplateNow: suspend () -> Result<TemplateSyncOutcome> = {
+        Result.failure(UnsupportedOperationException("template sharing unavailable"))
+    },
     private val externalChangeFlow: StateFlow<ExternalChangeNotice?> = NO_EXTERNAL_CHANGE_FLOW,
     private val syncTemplateTaggedHeading: suspend (String) -> Result<Boolean> = { Result.success(false) },
     private val syncSnapshotFlow: StateFlow<SyncIntegrationSnapshot> = MutableStateFlow(SyncIntegrationSnapshot()),
@@ -321,6 +325,10 @@ class OrgClockStore(
         }
         OrgClockUiAction.CreateDefaultTemplateFile -> {
             scope.launch { createDefaultTemplateFile() }
+            true
+        }
+        OrgClockUiAction.SyncTemplateNow -> {
+            scope.launch { synchronizeTemplate() }
             true
         }
         else -> false
@@ -1420,6 +1428,30 @@ class OrgClockStore(
         _uiState.update {
             it.copy(
                 status = status(StatusMessageKey.TemplateFileCreated, StatusTone.Success, result.getOrThrow()),
+            )
+        }
+    }
+
+    private suspend fun synchronizeTemplate() {
+        _uiState.update { it.copy(templateSyncInProgress = true, templateSyncMessage = null) }
+        val message = syncTemplateNow().fold(
+            onSuccess = { outcome ->
+                when (outcome) {
+                    TemplateSyncOutcome.AlreadyCurrent -> "Template is already synchronized."
+                    is TemplateSyncOutcome.Downloaded -> "Template downloaded from the paired device."
+                    is TemplateSyncOutcome.Uploaded -> "Template uploaded to the paired device."
+                    is TemplateSyncOutcome.Conflict -> "Template conflict detected. Neither version was overwritten."
+                }
+            },
+            onFailure = { it.message ?: "Template sync failed." },
+        )
+        uiState.value.rootReference?.let { root ->
+            refreshTemplateState(root, loadRootScheduleConfig(root))
+        }
+        _uiState.update {
+            it.copy(
+                templateSyncInProgress = false,
+                templateSyncMessage = message,
             )
         }
     }

--- a/shared/src/commonTest/kotlin/com/example/orgclock/template/TemplateSharingJsonCodecTest.kt
+++ b/shared/src/commonTest/kotlin/com/example/orgclock/template/TemplateSharingJsonCodecTest.kt
@@ -1,0 +1,49 @@
+package com.example.orgclock.template
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TemplateSharingJsonCodecTest {
+    private val revision = SharedTemplateRevision(
+        revisionId = "rev-2",
+        parentRevisionId = "rev-1",
+        content = "* Work\n** Task\n",
+        contentHash = "hash-2",
+        updatedAt = Instant.parse("2026-06-12T00:00:00Z"),
+        updatedByDeviceId = "desktop-a",
+    )
+
+    @Test
+    fun fetchResponse_roundTrips() {
+        val original = TemplateFetchResponse("android-a", "desktop-a", revision)
+
+        val decoded = TemplateSharingJsonCodec.decodeFetchResponse(
+            TemplateSharingJsonCodec.encodeFetchResponse(original),
+        )
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun pushRequest_roundTripsWithExpectedRevision() {
+        val original = TemplatePushRequest("desktop-a", "android-a", revision, "rev-1")
+
+        val decoded = TemplateSharingJsonCodec.decodePushRequest(
+            TemplateSharingJsonCodec.encodePushRequest(original),
+        )
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun conflictResult_roundTrips() {
+        val original = TemplatePushResult.Conflict("rev-other", "rev-2")
+
+        val decoded = TemplateSharingJsonCodec.decodePushResult(
+            TemplateSharingJsonCodec.encodePushResult(original),
+        )
+
+        assertEquals(original, decoded)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/example/orgclock/template/TemplateSharingServiceTest.kt
+++ b/shared/src/commonTest/kotlin/com/example/orgclock/template/TemplateSharingServiceTest.kt
@@ -1,0 +1,90 @@
+package com.example.orgclock.template
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TemplateSharingServiceTest {
+    @Test
+    fun emptyLocal_downloadsRemoteTemplate() = runTest {
+        val remote = revision("remote-1", null)
+        val localStore = MemoryTemplateStore(null)
+        val transport = MemoryTemplateTransport(remote)
+
+        val outcome = TemplateSharingService(localStore, transport, "local", "remote")
+            .synchronize().getOrThrow()
+
+        assertEquals(TemplateSyncOutcome.Downloaded("remote-1"), outcome)
+        assertEquals(remote, localStore.current)
+    }
+
+    @Test
+    fun localChild_uploadsAsFastForward() = runTest {
+        val remote = revision("base", null)
+        val local = revision("local-2", "base")
+        val transport = MemoryTemplateTransport(remote)
+
+        val outcome = TemplateSharingService(MemoryTemplateStore(local), transport, "local", "remote")
+            .synchronize().getOrThrow()
+
+        assertEquals(TemplateSyncOutcome.Uploaded("local-2"), outcome)
+        assertEquals(local, transport.current)
+    }
+
+    @Test
+    fun divergentChildren_reportConflictWithoutOverwrite() = runTest {
+        val local = revision("local-2", "base")
+        val remote = revision("remote-2", "base")
+        val localStore = MemoryTemplateStore(local)
+        val transport = MemoryTemplateTransport(remote)
+
+        val outcome = TemplateSharingService(localStore, transport, "local", "remote")
+            .synchronize().getOrThrow()
+
+        assertEquals(TemplateSyncOutcome.Conflict("local-2", "remote-2"), outcome)
+        assertEquals(local, localStore.current)
+        assertEquals(remote, transport.current)
+    }
+
+    private fun revision(id: String, parent: String?) = SharedTemplateRevision(
+        revisionId = id,
+        parentRevisionId = parent,
+        content = "* $id\n",
+        contentHash = "hash-$id",
+        updatedAt = Instant.parse("2026-06-12T00:00:00Z"),
+        updatedByDeviceId = "device",
+    )
+}
+
+private class MemoryTemplateStore(
+    var current: SharedTemplateRevision?,
+) : SharedTemplateStore {
+    override suspend fun readRevision(): Result<SharedTemplateRevision?> = Result.success(current)
+
+    override suspend fun writeRevision(
+        revision: SharedTemplateRevision,
+        expectedCurrentRevisionId: String?,
+    ): Result<TemplatePushResult> {
+        if (current?.revisionId != expectedCurrentRevisionId) {
+            return Result.success(TemplatePushResult.Conflict(current?.revisionId, revision.revisionId))
+        }
+        current = revision
+        return Result.success(TemplatePushResult.Accepted(revision.revisionId))
+    }
+}
+
+private class MemoryTemplateTransport(
+    var current: SharedTemplateRevision?,
+) : TemplateSyncTransport {
+    override suspend fun fetchTemplate(request: TemplateFetchRequest): TemplateFetchResponse =
+        TemplateFetchResponse(request.targetPeerId, request.sourcePeerId, current)
+
+    override suspend fun pushTemplate(request: TemplatePushRequest): TemplatePushResult {
+        if (current?.revisionId != request.expectedCurrentRevisionId) {
+            return TemplatePushResult.Conflict(current?.revisionId, request.revision.revisionId)
+        }
+        current = request.revision
+        return TemplatePushResult.Accepted(request.revision.revisionId)
+    }
+}


### PR DESCRIPTION
## Summary
- add a revision-based template sharing protocol with conflict detection
- integrate template synchronization into Android and desktop paired-device flows
- add Windows MSI install, shortcut, runtime, and uninstall smoke testing
- run the Windows installer smoke test in verification and release workflows

## Impact
Users can synchronize an existing template when setting up another device. Windows desktop releases now verify the installed application and shortcuts before publication.

## Validation
- `./gradlew.bat :shared:jvmTest :desktopApp:test :app:testDebugUnitTest`
- `./scripts/desktop-smoke-test.ps1`
- `git diff --check`
- PowerShell parser validation for `scripts/desktop-smoke-test.ps1`