### PR TITLE
[codex] Harden Windows desktop runtime reliability

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -66,11 +66,11 @@ jobs:
           chmod +x ./gradlew
           ./gradlew --stacktrace packageDesktopCurrentOs -Pdesktop.version="${{ steps.release.outputs.version }}"
 
-      - name: Smoke test Windows installer layout
+      - name: Smoke test Windows installed runtime
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          & .\scripts\desktop-smoke-test.ps1 -SkipBuild -InstallerOnly
+          & .\scripts\desktop-smoke-test.ps1 -SkipBuild
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Collect Linux installers

--- a/.github/workflows/verify-desktop-windows.yml
+++ b/.github/workflows/verify-desktop-windows.yml
@@ -78,10 +78,10 @@ jobs:
           & .\gradlew.bat --stacktrace packageDesktopCurrentOs *>&1 | Tee-Object -FilePath artifacts/desktop-windows/package-desktop-current-os.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Smoke test Windows installer layout
+      - name: Smoke test Windows installed runtime
         shell: pwsh
         run: |
-          & .\scripts\desktop-smoke-test.ps1 -SkipBuild -InstallerOnly
+          & .\scripts\desktop-smoke-test.ps1 -SkipBuild
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload desktop artifacts

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -54,7 +54,7 @@ compose.desktop {
 
         nativeDistributions {
             targetFormats(*desktopTargetFormats)
-            modules("java.sql")
+            modules("java.sql", "jdk.httpserver")
             packageName = if (desktopSmokePackage) {
                 "org-clock-desktop-smoke"
             } else {

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopAppGraph.kt
@@ -47,6 +47,24 @@ class DesktopAppGraph(
     private val syncIdentity: DesktopSyncIdentity = DesktopSyncIdentity(),
     private val repositoryFactory: (Path) -> ClockRepository = ::DesktopFileOrgRepository,
     private val coordinatorFactory: () -> FileOperationCoordinator = ::InMemoryFileOperationCoordinator,
+    private val pairingManager: DesktopPairingManager = DesktopPairingManager(),
+    private val lanSyncServerFactory: (
+        Path,
+        ClockEventStore,
+        DesktopPeerTrustStore,
+        SharedTemplateStore,
+        RemoteClockEventApplier,
+    ) -> DesktopLanSyncServer = { root, eventStore, trustStore, templateStore, applier ->
+        DesktopLanSyncServer(
+            localDeviceId = { syncIdentity.deviceId(root) },
+            eventStore = { eventStore },
+            trustStore = { trustStore },
+            tlsIdentity = { syncIdentity.tlsIdentity(root) },
+            pairingManager = pairingManager,
+            remoteEventApplier = applier,
+            templateStore = { templateStore },
+        )
+    },
     private val watchRootChanges: Boolean = true,
 ) {
     private var currentRootPath: Path? = null
@@ -62,7 +80,6 @@ class DesktopAppGraph(
     private var rootWatcher: DesktopRootWatcher? = null
     private var scope: CoroutineScope? = null
     private var lanSyncServer: DesktopLanSyncServer? = null
-    private val pairingManager = DesktopPairingManager()
     private val externalChangeFlow = MutableStateFlow<ExternalChangeNotice?>(null)
     private val clockEventSyncSnapshotFlow = MutableStateFlow(ClockEventStoreSnapshot(null, null, 0))
     private val desktopEventSyncRuntimeInstance: DesktopEventSyncRuntime by lazy {
@@ -250,6 +267,14 @@ class DesktopAppGraph(
                 snapshotPublisher = { clockEventSyncSnapshotFlow.value = it },
             ),
         )
+        val remoteClockEventApplier = RepositoryRemoteClockEventApplier(
+            repository = repository,
+            clockService = ClockService(repository, fileOperationCoordinator = fileOperationCoordinator),
+            timeZoneProvider = clockEnvironment::currentTimeZone,
+        )
+        desktopEventSyncRuntimeInstance.cancelPendingSync()
+        lanSyncServer?.close()
+        rootWatcher?.stop()
         currentRootPath = normalized
         this.repository = repository
         this.clockEventStore = eventStore
@@ -258,36 +283,29 @@ class DesktopAppGraph(
         this.quarantineStore = quarantineStore
         this.sharedTemplateStore = templateStore
         this.clockService = clockService
-        this.remoteClockEventApplier = RepositoryRemoteClockEventApplier(
-            repository = repository,
-            clockService = ClockService(repository, fileOperationCoordinator = fileOperationCoordinator),
-            timeZoneProvider = clockEnvironment::currentTimeZone,
-        )
+        this.remoteClockEventApplier = remoteClockEventApplier
         this.openClockScanner = DesktopOpenClockScanner(repository)
-        if (watchRootChanges) {
-            lanSyncServer?.close()
-            lanSyncServer = DesktopLanSyncServer(
-                localDeviceId = { syncIdentity.deviceId(normalized) },
-                eventStore = { this.clockEventStore },
-                trustStore = { this.peerTrustStore },
-                tlsIdentity = { syncIdentity.tlsIdentity(normalized) },
-                pairingManager = pairingManager,
-                remoteEventApplier = requireNotNull(remoteClockEventApplier),
-                templateStore = { this.sharedTemplateStore },
-            ).also { it.start() }
+        lanSyncServer = if (watchRootChanges) {
+            runCatching {
+                lanSyncServerFactory(normalized, eventStore, trustStore, templateStore, remoteClockEventApplier)
+                    .also { it.start() }
+            }.getOrNull()
+        } else {
+            null
+        }
+        rootWatcher = scope?.takeIf { watchRootChanges }?.let { scope ->
+            runCatching {
+                DesktopRootWatcher(
+                    rootPath = normalized,
+                    scope = scope,
+                    onChange = { notice ->
+                        externalChangeFlow.value = notice.copy(revision = ++externalChangeRevision)
+                    },
+                ).also { it.start() }
+            }.getOrNull()
         }
         clockEventSyncSnapshotFlow.value = ClockEventStoreSnapshot(null, null, 0)
         desktopEventSyncRuntimeInstance.onRootOpened()
-        rootWatcher?.stop()
-        scope?.takeIf { watchRootChanges }?.let { scope ->
-            rootWatcher = DesktopRootWatcher(
-                rootPath = normalized,
-                scope = scope,
-                onChange = { notice ->
-                    externalChangeFlow.value = notice.copy(revision = ++externalChangeRevision)
-                },
-            ).also { it.start() }
-        }
     }
 
     private fun normalizeRoot(rootReference: RootReference): Path {
@@ -351,12 +369,12 @@ class DesktopAppGraph(
     }
 
     private fun desktopCheckpointStorePreferences(rootPath: Path): java.util.prefs.Preferences {
-        val nodeName = "com/example/orgclock/desktop/sync/checkpoints/${rootPath.toString().hashCode()}"
+        val nodeName = "com/example/orgclock/desktop/sync/checkpoints/${stableRootKey(rootPath).hashCode()}"
         return java.util.prefs.Preferences.userRoot().node(nodeName)
     }
 
     private fun desktopQuarantineStorePreferences(rootPath: Path): java.util.prefs.Preferences {
-        val nodeName = "com/example/orgclock/desktop/sync/quarantine/${rootPath.toString().hashCode()}"
+        val nodeName = "com/example/orgclock/desktop/sync/quarantine/${stableRootKey(rootPath).hashCode()}"
         return java.util.prefs.Preferences.userRoot().node(nodeName)
     }
 

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopEventSyncRuntime.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopEventSyncRuntime.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.datetime.Clock
 import java.util.logging.Logger
@@ -74,6 +75,7 @@ class DesktopEventSyncRuntime(
     private val _state = MutableStateFlow(DesktopEventSyncRuntimeState())
     val state: StateFlow<DesktopEventSyncRuntimeState> = _state.asStateFlow()
     private var snapshotObserver: Job? = null
+    private var syncJob: Job? = null
 
     fun onAppStarted() {
         start("startup")
@@ -98,7 +100,14 @@ class DesktopEventSyncRuntime(
     fun stop() {
         snapshotObserver?.cancel()
         snapshotObserver = null
+        cancelPendingSync()
         _state.update { it.copy(running = false) }
+    }
+
+    @Synchronized
+    fun cancelPendingSync() {
+        syncJob?.cancel()
+        syncJob = null
     }
 
     fun setMode(mode: DesktopEventSyncMode) {
@@ -140,9 +149,18 @@ class DesktopEventSyncRuntime(
         }
     }
 
+    @Synchronized
     private fun scheduleSync(reason: String) {
-        scope.launch {
-            syncNow(reason)
+        if (syncJob?.isActive == true) return
+        syncJob = scope.launch {
+            try {
+                syncNow(reason)
+            } finally {
+                val completedJob = currentCoroutineContext()[Job]
+                synchronized(this@DesktopEventSyncRuntime) {
+                    if (syncJob === completedJob) syncJob = null
+                }
+            }
         }
     }
 

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncServer.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopLanSyncServer.kt
@@ -20,9 +20,10 @@ import com.sun.net.httpserver.HttpsServer
 import java.net.InetSocketAddress
 import java.security.MessageDigest
 import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.runBlocking
 
-class DesktopLanSyncServer(
+open class DesktopLanSyncServer(
     private val port: Int = DesktopSyncIdentity.DEFAULT_PORT,
     private val localDeviceId: () -> String,
     private val eventStore: () -> ClockEventStore?,
@@ -33,12 +34,16 @@ class DesktopLanSyncServer(
     private val templateStore: () -> SharedTemplateStore?,
 ) : AutoCloseable {
     private var server: HttpsServer? = null
+    private var executor: ExecutorService? = null
 
-    fun start() {
+    open fun start() {
         if (server != null) return
-        server = HttpsServer.create(InetSocketAddress("0.0.0.0", port), 0).apply {
+        val executor = Executors.newFixedThreadPool(4) { Thread(it, "org-clock-lan-sync").apply { isDaemon = true } }
+        this.executor = executor
+        try {
+            server = HttpsServer.create(InetSocketAddress("0.0.0.0", port), 0).apply {
             httpsConfigurator = HttpsConfigurator(tlsIdentity().sslContext)
-            executor = Executors.newFixedThreadPool(4) { Thread(it, "org-clock-lan-sync").apply { isDaemon = true } }
+            this.executor = executor
             createContext("/v1/health") { exchange ->
                 if (exchange.requestMethod != "GET") exchange.respond(405, "method not allowed")
                 else exchange.respond(200, "ok", "text/plain; charset=utf-8")
@@ -122,11 +127,20 @@ class DesktopLanSyncServer(
                 }
                 TemplateSharingJsonCodec.encodePushResult(result)
             } }
-            start()
+                start()
+            }
+        } catch (error: Throwable) {
+            close()
+            throw error
         }
     }
 
-    override fun close() { server?.stop(0); server = null }
+    override open fun close() {
+        server?.stop(0)
+        server = null
+        executor?.shutdownNow()
+        executor = null
+    }
 
     private fun handlePost(exchange: HttpExchange, handler: (String) -> String) {
         if (exchange.requestMethod != "POST") return exchange.respond(405, "method not allowed")

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopRootWatcher.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopRootWatcher.kt
@@ -14,6 +14,7 @@ import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
 import java.nio.file.StandardWatchEventKinds.OVERFLOW
 import java.nio.file.WatchService
 import java.nio.file.WatchKey
+import java.nio.file.ClosedWatchServiceException
 import kotlin.io.path.extension
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
@@ -41,7 +42,10 @@ class DesktopRootWatcher(
             while (isActive) {
                 val key = try {
                     watchService.take()
-                } catch (_: Throwable) {
+                } catch (_: ClosedWatchServiceException) {
+                    break
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
                     break
                 }
                 var overflowed = false

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSettingsStore.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSettingsStore.kt
@@ -1,7 +1,14 @@
 package com.example.orgclock.desktop
 
 import com.example.orgclock.presentation.RootReference
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.io.IOException
 import java.util.prefs.Preferences
+import kotlin.io.path.exists
 
 data class DesktopHostSettings(
     val lastRootReference: RootReference? = null,
@@ -9,9 +16,17 @@ data class DesktopHostSettings(
 
 class DesktopSettingsStore(
     private val preferences: Preferences = Preferences.userRoot().node(PREFERENCES_NODE),
+    private val fallbackFile: Path? = defaultFallbackFile(),
 ) {
     fun load(): DesktopHostSettings {
-        val rawRoot = preferences.get(KEY_LAST_ROOT, null)
+        val fallbackExists = fallbackFile?.exists() == true
+        val rawRoot = if (fallbackExists) {
+            fallbackFile?.let { file ->
+                runCatching { Files.readString(file, StandardCharsets.UTF_8).trim() }.getOrNull()
+            }
+        } else {
+            runCatching { preferences.get(KEY_LAST_ROOT, null) }.getOrNull()
+        }
         return DesktopHostSettings(
             lastRootReference = rawRoot?.takeIf { it.isNotBlank() }?.let(::RootReference),
         )
@@ -19,21 +34,64 @@ class DesktopSettingsStore(
 
     fun save(settings: DesktopHostSettings) {
         val root = settings.lastRootReference?.rawValue
-        if (root.isNullOrBlank()) {
-            preferences.remove(KEY_LAST_ROOT)
-        } else {
-            preferences.put(KEY_LAST_ROOT, root)
+        runCatching {
+            if (root.isNullOrBlank()) {
+                preferences.remove(KEY_LAST_ROOT)
+            } else {
+                preferences.put(KEY_LAST_ROOT, root)
+            }
+            preferences.flush()
         }
-        preferences.flush()
+        fallbackFile?.let { file ->
+            writeFallback(file, root.orEmpty())
+        }
     }
 
     fun clear() {
-        preferences.remove(KEY_LAST_ROOT)
-        preferences.flush()
+        runCatching {
+            preferences.remove(KEY_LAST_ROOT)
+            preferences.flush()
+        }
+        fallbackFile?.let { file ->
+            writeFallback(file, "")
+        }
+    }
+
+    private fun writeFallback(file: Path, value: String) {
+        file.parent?.let(Files::createDirectories)
+        val temp = Files.createTempFile(file.parent, ".desktop-root.", ".tmp")
+        try {
+            Files.writeString(
+                temp,
+                value,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE,
+            )
+            try {
+                Files.move(temp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+            } catch (atomicError: IOException) {
+                try {
+                    Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING)
+                } catch (fallbackError: IOException) {
+                    fallbackError.addSuppressed(atomicError)
+                    throw fallbackError
+                }
+            }
+        } finally {
+            Files.deleteIfExists(temp)
+        }
     }
 
     private companion object {
         const val PREFERENCES_NODE = "com/example/orgclock/desktop"
         const val KEY_LAST_ROOT = "last_root"
+
+        fun defaultFallbackFile(): Path? {
+            val base = System.getenv("LOCALAPPDATA")?.takeIf { it.isNotBlank() }
+                ?: System.getProperty("user.home")?.takeIf { it.isNotBlank() }
+                ?: return null
+            return Path.of(base, "OrgClock", "desktop-root.txt")
+        }
     }
 }

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSharedTemplateStore.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSharedTemplateStore.kt
@@ -6,11 +6,14 @@ import com.example.orgclock.template.TemplatePushResult
 import kotlinx.datetime.Clock
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.io.IOException
 import java.security.MessageDigest
 import java.util.prefs.Preferences
 import kotlin.io.path.exists
 import kotlin.io.path.readText
-import kotlin.io.path.writeText
 
 class DesktopSharedTemplateStore(
     private val rootPath: Path,
@@ -54,7 +57,7 @@ class DesktopSharedTemplateStore(
         }
         val content = canonicalContent(revision.content)
         require(stableHash(content) == revision.contentHash) { "Template content hash mismatch" }
-        templatePath.writeText(content, StandardCharsets.UTF_8)
+        atomicWriteText(templatePath, content)
         persistMetadata(
             prefix,
             revision.revisionId,
@@ -67,11 +70,42 @@ class DesktopSharedTemplateStore(
     }
 
     private fun templatePath(): Path {
-        val path = templatePathProvider().toAbsolutePath().normalize()
-        require(path.startsWith(rootPath.toAbsolutePath().normalize())) {
+        val root = rootPath.toRealPath()
+        val requested = templatePathProvider().toAbsolutePath().normalize()
+        val path = if (requested.exists()) {
+            requested.toRealPath()
+        } else {
+            requested.parent.toRealPath().resolve(requested.fileName)
+        }
+        require(path.startsWith(root)) {
             "Shared template must be inside the org root"
         }
         return path
+    }
+
+    private fun atomicWriteText(path: Path, content: String) {
+        val temp = Files.createTempFile(path.parent, ".${path.fileName}.", ".tmp")
+        try {
+            Files.writeString(
+                temp,
+                content,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE,
+            )
+            try {
+                Files.move(temp, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+            } catch (atomicError: IOException) {
+                try {
+                    Files.move(temp, path, StandardCopyOption.REPLACE_EXISTING)
+                } catch (fallbackError: IOException) {
+                    fallbackError.addSuppressed(atomicError)
+                    throw fallbackError
+                }
+            }
+        } finally {
+            Files.deleteIfExists(temp)
+        }
     }
 
     private fun revisionFromPreferences(

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommand.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommand.kt
@@ -14,6 +14,7 @@ import kotlinx.datetime.TimeZone
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.prefs.Preferences
 import kotlin.io.path.absolute
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
@@ -70,25 +71,46 @@ internal object DesktopSmokeTestCommand {
                 }
                 checks += check("desktop_graph_root_open") {
                     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-                    val graph = DesktopAppGraph(watchRootChanges = true)
+                    val preferences = Preferences.userRoot().node(
+                        "com/example/orgclock/desktop/smoke/${System.nanoTime()}",
+                    )
+                    val fallbackFile = root.resolve(".orgclock/smoke-root.txt")
+                    val graph = DesktopAppGraph(
+                        settingsStore = DesktopSettingsStore(preferences, fallbackFile),
+                        rootScheduleStore = DesktopRootScheduleStore(preferences.node("schedule")),
+                        watchRootChanges = true,
+                    )
                     try {
                         val store = graph.createStore(scope)
                         store.onAction(com.example.orgclock.ui.state.OrgClockUiAction.Initialize)
-                        waitFor("Desktop graph initialization") {
-                            store.uiState.value.screen == com.example.orgclock.presentation.Screen.RootSetup
-                        }
                         store.onAction(com.example.orgclock.ui.state.OrgClockUiAction.PickRoot(
                             com.example.orgclock.presentation.RootReference(root.toString()),
                         ))
-                        waitFor("Desktop graph root open") {
-                            graph.currentRootReference() != null
+                        waitFor("Desktop graph root open", details = {
+                            val state = store.uiState.value
+                            "screen=${state.screen}, status=${state.status.text.key}, " +
+                                "root=${state.rootReference?.rawValue}, files=${state.files.size}"
+                        }) {
+                            val state = store.uiState.value
+                            graph.currentRootReference()?.rawValue
+                                ?.let(Path::of)
+                                ?.let { runCatching { it.toRealPath() }.getOrNull() } == root.toRealPath() &&
+                                state.files.any { it.displayName == "2026-01-02.org" }
                         }
-                        require(graph.currentRootReference()?.rawValue == root.toString()) {
+                        require(
+                            graph.currentRootReference()?.rawValue
+                                ?.let(Path::of)
+                                ?.toRealPath() == root.toRealPath(),
+                        ) {
                             "Desktop graph did not open the smoke root"
                         }
                     } finally {
                         graph.close()
                         scope.cancel()
+                        runCatching {
+                            preferences.removeNode()
+                            preferences.parent()?.flush()
+                        }
                     }
                 }
             }
@@ -145,12 +167,16 @@ internal object DesktopSmokeTestCommand {
             onFailure = { SmokeCheck(name, false, it.stackTraceToString()) },
         )
 
-    private suspend fun waitFor(description: String, condition: () -> Boolean) {
+    private suspend fun waitFor(
+        description: String,
+        details: () -> String = { "" },
+        condition: () -> Boolean,
+    ) {
         repeat(250) {
             if (condition()) return
             kotlinx.coroutines.delay(20)
         }
-        error("$description timed out")
+        error("$description timed out: ${details()}")
     }
 
     private fun reportJson(root: Path, checks: List<SmokeCheck>): String = buildString {

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommand.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSmokeTestCommand.kt
@@ -5,6 +5,10 @@ import com.example.orgclock.domain.ClockService
 import com.example.orgclock.model.HeadingPath
 import com.example.orgclock.sync.JdbcClockEventStore
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import java.nio.charset.StandardCharsets
@@ -64,6 +68,29 @@ internal object DesktopSmokeTestCommand {
                     require(template.exists()) { "Template fixture is missing" }
                     require(template.readText().contains("Packaged runtime")) { "Template contents were not readable" }
                 }
+                checks += check("desktop_graph_root_open") {
+                    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                    val graph = DesktopAppGraph(watchRootChanges = true)
+                    try {
+                        val store = graph.createStore(scope)
+                        store.onAction(com.example.orgclock.ui.state.OrgClockUiAction.Initialize)
+                        waitFor("Desktop graph initialization") {
+                            store.uiState.value.screen == com.example.orgclock.presentation.Screen.RootSetup
+                        }
+                        store.onAction(com.example.orgclock.ui.state.OrgClockUiAction.PickRoot(
+                            com.example.orgclock.presentation.RootReference(root.toString()),
+                        ))
+                        waitFor("Desktop graph root open") {
+                            graph.currentRootReference() != null
+                        }
+                        require(graph.currentRootReference()?.rawValue == root.toString()) {
+                            "Desktop graph did not open the smoke root"
+                        }
+                    } finally {
+                        graph.close()
+                        scope.cancel()
+                    }
+                }
             }
         }.fold(
             onSuccess = { 0 },
@@ -117,6 +144,14 @@ internal object DesktopSmokeTestCommand {
             onSuccess = { SmokeCheck(name, true, null) },
             onFailure = { SmokeCheck(name, false, it.stackTraceToString()) },
         )
+
+    private suspend fun waitFor(description: String, condition: () -> Boolean) {
+        repeat(250) {
+            if (condition()) return
+            kotlinx.coroutines.delay(20)
+        }
+        error("$description timed out")
+    }
 
     private fun reportJson(root: Path, checks: List<SmokeCheck>): String = buildString {
         append("{\n")

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSyncIdentity.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopSyncIdentity.kt
@@ -7,6 +7,7 @@ import com.example.orgclock.sync.SyncPairingInvitationCodec
 import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.nio.file.Path
+import java.util.Locale
 
 class DesktopSyncIdentity(
     private val port: Int = DEFAULT_PORT,
@@ -27,18 +28,40 @@ class DesktopSyncIdentity(
         )
     }
 
-    fun deviceId(rootPath: Path): String = "desktop-${rootPath.toString().hashCode()}"
+    fun deviceId(rootPath: Path): String = "desktop-${stableRootKey(rootPath).hashCode()}"
     fun tlsIdentity(rootPath: Path): DesktopTlsIdentity = DesktopTlsIdentity.loadOrCreate(rootPath)
 
     private fun findLanAddress(): String? = NetworkInterface.getNetworkInterfaces().toList()
         .asSequence()
         .filter { it.isUp && !it.isLoopback && !it.isVirtual }
-        .flatMap { it.inetAddresses.toList().asSequence() }
-        .filterIsInstance<Inet4Address>()
-        .map { it.hostAddress }
-        .firstOrNull { !it.startsWith("169.254.") }
+        .flatMap { network ->
+            network.inetAddresses.toList()
+                .filterIsInstance<Inet4Address>()
+                .map { address -> network to address }
+        }
+        .filter { (_, address) -> !address.hostAddress.startsWith("169.254.") }
+        .sortedByDescending { (network, address) ->
+            var score = if (address.isSiteLocalAddress) 100 else 0
+            val label = "${network.name} ${network.displayName}".lowercase(Locale.ROOT)
+            if (VIRTUAL_ADAPTER_MARKERS.any(label::contains)) score -= 50
+            score
+        }
+        .map { (_, address) -> address.hostAddress }
+        .firstOrNull()
 
     companion object {
         const val DEFAULT_PORT = 8787
+        val VIRTUAL_ADAPTER_MARKERS = listOf("vpn", "virtual", "vethernet", "hyper-v", "wsl", "docker")
+    }
+}
+
+internal fun stableRootKey(rootPath: Path): String {
+    val canonical = runCatching { rootPath.toRealPath() }
+        .getOrElse { rootPath.toAbsolutePath().normalize() }
+        .toString()
+    return if (System.getProperty("os.name").orEmpty().lowercase(Locale.ROOT).contains("windows")) {
+        canonical.lowercase(Locale.ROOT)
+    } else {
+        canonical
     }
 }

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopTlsIdentity.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/DesktopTlsIdentity.kt
@@ -33,7 +33,7 @@ class DesktopTlsIdentity private constructor(
         fun loadOrCreate(rootPath: Path): DesktopTlsIdentity {
             ensureProvider()
             val rootKey = MessageDigest.getInstance("SHA-256")
-                .digest(rootPath.toAbsolutePath().normalize().toString().encodeToByteArray())
+                .digest(stableRootKey(rootPath).encodeToByteArray())
                 .joinToString("") { "%02x".format(it) }
                 .take(24)
             val directory = Path.of(System.getProperty("user.home"), ".orgclock", "tls", rootKey)

--- a/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/example/orgclock/desktop/Main.kt
@@ -83,8 +83,15 @@ import javax.swing.JFileChooser
 
 fun main(args: Array<String>) {
     if (DesktopSmokeTestCommand.isRequested(args)) {
-        DesktopSmokeTestCommand.run(args)
-        return
+        val exitCode = runCatching { DesktopSmokeTestCommand.run(args) }
+            .fold(
+                onSuccess = { 0 },
+                onFailure = {
+                    it.printStackTrace()
+                    1
+                },
+            )
+        kotlin.system.exitProcess(exitCode)
     }
     launchDesktopApplication()
 }

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopAppGraphTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopAppGraphTest.kt
@@ -51,7 +51,7 @@ class DesktopAppGraphTest {
     fun restoresSavedRootOnStartupThroughSharedStore() = runTest {
         val root = tempRoot()
         write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
-        val store = DesktopSettingsStore(testNode())
+        val store = DesktopSettingsStore(testNode(), fallbackFile = null)
         store.save(DesktopHostSettings(lastRootReference = RootReference(root.toString())))
         val scheduleStore = DesktopRootScheduleStore(testNode())
 
@@ -79,7 +79,7 @@ class DesktopAppGraphTest {
     fun pickingRootPersistsAndEnablesDesktopClockOperations() = runTest {
         val root = tempRoot()
         write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
-        val settingsStore = DesktopSettingsStore(testNode())
+        val settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null)
         val scheduleStore = DesktopRootScheduleStore(testNode())
         val graph = DesktopAppGraph(
             settingsStore = settingsStore,
@@ -119,7 +119,7 @@ class DesktopAppGraphTest {
         val template = root.resolve("project-template.org")
         write(daily, "* Work\n** Task\n")
         write(template, "* Template\n")
-        val settingsStore = DesktopSettingsStore(testNode())
+        val settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null)
         val scheduleStore = DesktopRootScheduleStore(testNode())
         val graph = DesktopAppGraph(
             settingsStore = settingsStore,
@@ -158,7 +158,7 @@ class DesktopAppGraphTest {
         val hiddenTemplate = root.resolve(".orgclock-template.org")
         write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
         write(hiddenTemplate, "* Default Template\n")
-        val settingsStore = DesktopSettingsStore(testNode())
+        val settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null)
         val scheduleStore = DesktopRootScheduleStore(testNode())
         scheduleStore.save(
             RootScheduleConfig(
@@ -193,7 +193,7 @@ class DesktopAppGraphTest {
         val root = tempRoot()
         write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
         val graph = DesktopAppGraph(
-            settingsStore = DesktopSettingsStore(testNode()).also {
+            settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null).also {
                 it.save(DesktopHostSettings(lastRootReference = RootReference(root.toString())))
             },
             rootScheduleStore = DesktopRootScheduleStore(testNode()),
@@ -217,7 +217,7 @@ class DesktopAppGraphTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun staleSavedRoot_isClearedAndReturnsToRootSetup() = runTest {
         val root = tempRoot()
-        val settingsStore = DesktopSettingsStore(testNode())
+        val settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null)
         settingsStore.save(DesktopHostSettings(lastRootReference = RootReference(root.toString())))
         Files.deleteIfExists(root)
 
@@ -234,6 +234,82 @@ class DesktopAppGraphTest {
 
         assertEquals(Screen.RootSetup, store.uiState.value.screen)
         assertEquals(null, settingsStore.load().lastRootReference)
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun lanSyncServerFailure_doesNotPreventRootFromOpening() = runTest {
+        val root = tempRoot()
+        write(root.resolve("2026-03-10.org"), "* Work\n** Task\n")
+        val graph = DesktopAppGraph(
+            settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null),
+            rootScheduleStore = DesktopRootScheduleStore(testNode()),
+            clockEnvironment = fixedClockEnvironment(),
+            lanSyncServerFactory = { _, _, _, _, _ ->
+                throw IllegalStateException("port is already in use")
+            },
+            watchRootChanges = true,
+        )
+        val store = graph.createStore(this)
+
+        store.onAction(OrgClockUiAction.PickRoot(RootReference(root.toString())))
+        advanceUntilIdle()
+
+        assertEquals(Screen.HeadingList, store.uiState.value.screen)
+        assertEquals(root.toString(), graph.currentRootReference()?.rawValue)
+        assertEquals("2026-03-10.org", store.uiState.value.selectedFile?.displayName)
+        graph.close()
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun switchingRoot_stopsOldRuntimeBeforeStartingNewRuntime() = runTest {
+        val firstRoot = tempRoot()
+        val secondRoot = tempRoot()
+        write(firstRoot.resolve("2026-03-10.org"), "* First\n")
+        write(secondRoot.resolve("2026-03-10.org"), "* Second\n")
+        var activeRuntime = false
+        var starts = 0
+        val graph = DesktopAppGraph(
+            settingsStore = DesktopSettingsStore(testNode(), fallbackFile = null),
+            rootScheduleStore = DesktopRootScheduleStore(testNode()),
+            clockEnvironment = fixedClockEnvironment(),
+            lanSyncServerFactory = { root, eventStore, trustStore, templateStore, applier ->
+                object : DesktopLanSyncServer(
+                    port = 0,
+                    localDeviceId = { root.toString() },
+                    eventStore = { eventStore },
+                    trustStore = { trustStore },
+                    tlsIdentity = { DesktopTlsIdentity.loadOrCreate(root) },
+                    pairingManager = DesktopPairingManager(),
+                    remoteEventApplier = applier,
+                    templateStore = { templateStore },
+                ) {
+                    override fun start() {
+                        check(!activeRuntime) { "old runtime is still active" }
+                        activeRuntime = true
+                        starts += 1
+                    }
+
+                    override fun close() {
+                        activeRuntime = false
+                    }
+                }
+            },
+            watchRootChanges = true,
+        )
+        val store = graph.createStore(this)
+
+        store.onAction(OrgClockUiAction.PickRoot(RootReference(firstRoot.toString())))
+        advanceUntilIdle()
+        store.onAction(OrgClockUiAction.PickRoot(RootReference(secondRoot.toString())))
+        advanceUntilIdle()
+
+        assertEquals(2, starts)
+        assertEquals(secondRoot.toString(), graph.currentRootReference()?.rawValue)
+        graph.close()
         coroutineContext.cancelChildren()
     }
 

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopAppGraphTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopAppGraphTest.kt
@@ -135,10 +135,17 @@ class DesktopAppGraphTest {
         advanceUntilIdle()
         store.onAction(OrgClockUiAction.OpenTemplateFilePicker)
         advanceUntilIdle()
-        store.onAction(OrgClockUiAction.SelectTemplateFile(store.uiState.value.templateCandidateFiles.first { it.fileId == template.toString() }))
+        val canonicalTemplate = template.toRealPath()
+        store.onAction(
+            OrgClockUiAction.SelectTemplateFile(
+                store.uiState.value.templateCandidateFiles.first {
+                    Path.of(it.fileId).toRealPath() == canonicalTemplate
+                },
+            ),
+        )
         advanceUntilIdle()
 
-        assertEquals(template.toString(), scheduleStore.load(root.toString()).templateFileUri)
+        assertEquals(canonicalTemplate.toString(), scheduleStore.load(root.toString()).templateFileUri)
         assertEquals(TemplateReferenceMode.Explicit, store.uiState.value.templateFileStatus.referenceMode)
 
         val restoredState = graph.createStore(this).run {
@@ -146,7 +153,7 @@ class DesktopAppGraphTest {
             advanceUntilIdle()
             uiState.value
         }
-        assertEquals(template.toString(), restoredState.templateFileStatus.fileId)
+        assertEquals(canonicalTemplate.toString(), restoredState.templateFileStatus.fileId)
         assertEquals(TemplateReferenceMode.Explicit, restoredState.templateFileStatus.referenceMode)
         coroutineContext.cancelChildren()
     }

--- a/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSettingsStoreTest.kt
+++ b/desktopApp/src/test/kotlin/com/example/orgclock/desktop/DesktopSettingsStoreTest.kt
@@ -5,10 +5,14 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.prefs.Preferences
+import kotlin.io.path.createTempDirectory
 
 class DesktopSettingsStoreTest {
     private val nodes = mutableListOf<Preferences>()
+    private val tempRoots = mutableListOf<Path>()
 
     @AfterTest
     fun cleanup() {
@@ -19,11 +23,17 @@ class DesktopSettingsStoreTest {
             }
         }
         nodes.clear()
+        tempRoots.asReversed().forEach { root ->
+            Files.walk(root).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+            }
+        }
+        tempRoots.clear()
     }
 
     @Test
     fun saveAndLoad_lastRootReference() {
-        val store = DesktopSettingsStore(testNode())
+        val store = DesktopSettingsStore(testNode(), fallbackFile = null)
 
         store.save(DesktopHostSettings(lastRootReference = RootReference("/tmp/org-root")))
 
@@ -33,10 +43,41 @@ class DesktopSettingsStoreTest {
 
     @Test
     fun clear_removesPersistedRoot() {
-        val store = DesktopSettingsStore(testNode())
+        val store = DesktopSettingsStore(testNode(), fallbackFile = null)
         store.save(DesktopHostSettings(lastRootReference = RootReference("/tmp/org-root")))
 
         store.clear()
+
+        assertNull(store.load().lastRootReference)
+    }
+
+    @Test
+    fun fallbackFile_restoresRootWhenPreferencesAreUnavailable() {
+        val fallbackFile = createTempDirectory("desktop-settings-test")
+            .also(tempRoots::add)
+            .resolve("desktop-root.txt")
+        DesktopSettingsStore(testNode(), fallbackFile).save(
+            DesktopHostSettings(lastRootReference = RootReference("C:\\Org Clock\\日本語")),
+        )
+
+        val loaded = DesktopSettingsStore(testNode(), fallbackFile).load()
+
+        assertEquals("C:\\Org Clock\\日本語", loaded.lastRootReference?.rawValue)
+    }
+
+    @Test
+    fun clear_tombstonePreventsStalePreferenceFromReturning() {
+        val fallbackFile = createTempDirectory("desktop-settings-test")
+            .also(tempRoots::add)
+            .resolve("desktop-root.txt")
+        val preferences = testNode()
+        preferences.put("last_root", "C:\\stale-root")
+        preferences.flush()
+        val store = DesktopSettingsStore(preferences, fallbackFile)
+
+        store.clear()
+        preferences.put("last_root", "C:\\stale-root")
+        preferences.flush()
 
         assertNull(store.load().lastRootReference)
     }

--- a/scripts/desktop-smoke-test.ps1
+++ b/scripts/desktop-smoke-test.ps1
@@ -12,7 +12,7 @@ param(
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $artifacts = Join-Path $repoRoot $ArtifactsDirectory
-$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) "org-clock-desktop-smoke\org-root-日本語"
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) "org-clock-desktop-smoke\org-root"
 $report = Join-Path $artifacts "smoke-report.json"
 $msiLog = Join-Path $artifacts "msi-install.log"
 

--- a/scripts/desktop-smoke-test.ps1
+++ b/scripts/desktop-smoke-test.ps1
@@ -12,7 +12,7 @@ param(
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $artifacts = Join-Path $repoRoot $ArtifactsDirectory
-$smokeRoot = Join-Path $artifacts "org-root-日本語"
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) "org-clock-desktop-smoke\org-root-日本語"
 $report = Join-Path $artifacts "smoke-report.json"
 $msiLog = Join-Path $artifacts "msi-install.log"
 

--- a/scripts/desktop-smoke-test.ps1
+++ b/scripts/desktop-smoke-test.ps1
@@ -38,24 +38,54 @@ function Start-ProcessWithTimeout {
         [string]$Description
     )
 
-    $process = Start-Process $FilePath -ArgumentList $ArgumentList -PassThru
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $ArgumentList) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw "$Description failed to start"
+    }
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
     if (-not $process.WaitForExit($ProcessTimeoutSeconds * 1000)) {
         Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
         throw "$Description timed out after $ProcessTimeoutSeconds seconds"
     }
-    return $process
+    $process.WaitForExit()
+    return [PSCustomObject]@{
+        ExitCode = $process.ExitCode
+        StandardOutput = $stdoutTask.GetAwaiter().GetResult()
+        StandardError = $stderrTask.GetAwaiter().GetResult()
+    }
 }
 
 function Write-SmokeDiagnostics {
     param(
         [string]$Executable,
-        [int]$ExitCode
+        [int]$ExitCode,
+        [string]$StandardOutput,
+        [string]$StandardError
     )
 
     Write-Host "Smoke executable: $Executable"
     Write-Host "Smoke root: $smokeRoot"
     Write-Host "Smoke report: $report"
     Write-Host "Smoke exit code: $ExitCode"
+    if (-not [string]::IsNullOrWhiteSpace($StandardOutput)) {
+        Write-Host "Smoke stdout:"
+        Write-Host $StandardOutput
+    }
+    if (-not [string]::IsNullOrWhiteSpace($StandardError)) {
+        Write-Host "Smoke stderr:"
+        Write-Host $StandardError
+    }
     if (Test-Path $report) {
         Write-Host "Smoke report contents:"
         Get-Content $report -Raw -Encoding UTF8 | Write-Host
@@ -80,11 +110,12 @@ $runtimeExe = Get-ChildItem (Join-Path $repoRoot "desktopApp/build/compose/binar
     Select-Object -ExpandProperty FullName -First 1
 if ($RuntimeOnly) {
     if (-not $runtimeExe) { throw "Distributable executable was not found. Run without -SkipBuild first." }
+    Remove-Item $report -Force -ErrorAction SilentlyContinue
     $runtimeSmoke = Start-ProcessWithTimeout $runtimeExe @(
-        "--smoke-test", "--root", "`"$smokeRoot`"", "--report", "`"$report`""
+        "--smoke-test", "--root", $smokeRoot, "--report", $report
     ) "Distributable executable smoke test"
     if ($runtimeSmoke.ExitCode -ne 0) {
-        Write-SmokeDiagnostics $runtimeExe $runtimeSmoke.ExitCode
+        Write-SmokeDiagnostics $runtimeExe $runtimeSmoke.ExitCode $runtimeSmoke.StandardOutput $runtimeSmoke.StandardError
         throw "Distributable executable smoke test failed with exit code $($runtimeSmoke.ExitCode)"
     }
     $result = Get-Content $report -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -114,7 +145,7 @@ $exeName = "$packageName.exe"
 $installedBySmoke = $false
 try {
     $install = Start-ProcessWithTimeout "msiexec.exe" @(
-        "/i", "`"$($msi.FullName)`"", "/qn", "/norestart", "/l*v", "`"$msiLog`""
+        "/i", $msi.FullName, "/qn", "/norestart", "/l*v", $msiLog
     ) "MSI installation"
     if ($install.ExitCode -ne 0) {
         if ($install.ExitCode -eq 1625) {
@@ -157,11 +188,12 @@ try {
         Write-Host "Start menu shortcut: $($startMenuShortcut.FullName)"
         Write-Host "Desktop shortcut: $($desktopShortcut.FullName)"
     } else {
+        Remove-Item $report -Force -ErrorAction SilentlyContinue
         $installedSmoke = Start-ProcessWithTimeout $exe @(
-            "--smoke-test", "--root", "`"$smokeRoot`"", "--report", "`"$report`""
+            "--smoke-test", "--root", $smokeRoot, "--report", $report
         ) "Packaged executable smoke test"
         if ($installedSmoke.ExitCode -ne 0) {
-            Write-SmokeDiagnostics $exe $installedSmoke.ExitCode
+            Write-SmokeDiagnostics $exe $installedSmoke.ExitCode $installedSmoke.StandardOutput $installedSmoke.StandardError
             throw "Packaged executable smoke test failed with exit code $($installedSmoke.ExitCode)"
         }
         $result = Get-Content $report -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -174,7 +206,7 @@ try {
 finally {
     if (-not $KeepInstalled -and $installedBySmoke) {
         $uninstall = Start-ProcessWithTimeout "msiexec.exe" @(
-            "/x", "`"$($msi.FullName)`"", "/qn", "/norestart"
+            "/x", $msi.FullName, "/qn", "/norestart"
         ) "MSI uninstall"
         if ($uninstall.ExitCode -ne 0) {
             Write-Warning "MSI uninstall failed with exit code $($uninstall.ExitCode)"

--- a/scripts/desktop-smoke-test.ps1
+++ b/scripts/desktop-smoke-test.ps1
@@ -46,6 +46,24 @@ function Start-ProcessWithTimeout {
     return $process
 }
 
+function Write-SmokeDiagnostics {
+    param(
+        [string]$Executable,
+        [int]$ExitCode
+    )
+
+    Write-Host "Smoke executable: $Executable"
+    Write-Host "Smoke root: $smokeRoot"
+    Write-Host "Smoke report: $report"
+    Write-Host "Smoke exit code: $ExitCode"
+    if (Test-Path $report) {
+        Write-Host "Smoke report contents:"
+        Get-Content $report -Raw -Encoding UTF8 | Write-Host
+    } else {
+        Write-Warning "Smoke report was not generated."
+    }
+}
+
 if (-not $SkipBuild) {
     $packageTask = if ($RuntimeOnly) { ":desktopApp:createDistributable" } else { ":desktopApp:packageMsi" }
     if (-not $SmokePackageVersion) {
@@ -66,6 +84,7 @@ if ($RuntimeOnly) {
         "--smoke-test", "--root", "`"$smokeRoot`"", "--report", "`"$report`""
     ) "Distributable executable smoke test"
     if ($runtimeSmoke.ExitCode -ne 0) {
+        Write-SmokeDiagnostics $runtimeExe $runtimeSmoke.ExitCode
         throw "Distributable executable smoke test failed with exit code $($runtimeSmoke.ExitCode)"
     }
     $result = Get-Content $report -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -142,6 +161,7 @@ try {
             "--smoke-test", "--root", "`"$smokeRoot`"", "--report", "`"$report`""
         ) "Packaged executable smoke test"
         if ($installedSmoke.ExitCode -ne 0) {
+            Write-SmokeDiagnostics $exe $installedSmoke.ExitCode
             throw "Packaged executable smoke test failed with exit code $($installedSmoke.ExitCode)"
         }
         $result = Get-Content $report -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/shared/src/jvmMain/kotlin/com/example/orgclock/data/DesktopFileOrgRepository.kt
+++ b/shared/src/jvmMain/kotlin/com/example/orgclock/data/DesktopFileOrgRepository.kt
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.nio.file.StandardCopyOption
+import java.io.IOException
 import java.security.MessageDigest
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -27,7 +29,7 @@ class DesktopFileOrgRepository(
     private val backupPolicy: BackupPolicyConfig = BackupPolicyConfig(),
     private val nowMsProvider: () -> Long = System::currentTimeMillis,
 ) : ClockRepository {
-    private val rootPath: Path = rootDirectory.absolute().normalize().createDirectories()
+    private val rootPath: Path = rootDirectory.absolute().normalize().createDirectories().toRealPath()
     private val lastClockBackupByFileId = mutableMapOf<String, Long>()
 
     init {
@@ -113,7 +115,7 @@ class DesktopFileOrgRepository(
         createIfMissing: Boolean,
         writeIntent: FileWriteIntent,
     ): SaveResult {
-        val normalizedPath = path.toAbsolutePath().normalize()
+        val normalizedPath = canonicalTarget(path)
         if (!isUnderRoot(normalizedPath)) {
             return SaveResult.ValidationError("File is outside repository root")
         }
@@ -155,14 +157,19 @@ class DesktopFileOrgRepository(
             val lineSeparator = existingRawText?.let(::detectLineSeparator) ?: "\n"
             val trailingNewline = existingRawText?.endsWith('\n') ?: false
             val outputText = formatOutputText(lines, lineSeparator, trailingNewline)
-            Files.writeString(
-                normalizedPath,
-                outputText,
-                StandardCharsets.UTF_8,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING,
-                StandardOpenOption.WRITE,
-            )
+            val tempPath = Files.createTempFile(normalizedPath.parent, ".${normalizedPath.fileName}.", ".tmp")
+            try {
+                Files.writeString(
+                    tempPath,
+                    outputText,
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE,
+                )
+                replaceFile(tempPath, normalizedPath)
+            } finally {
+                Files.deleteIfExists(tempPath)
+            }
             val roundTripRawText = normalizedPath.readText(StandardCharsets.UTF_8)
             val roundTripLines = parseLines(roundTripRawText)
             val expectedCanonicalText = canonicalText(lines)
@@ -192,7 +199,12 @@ class DesktopFileOrgRepository(
         if (existingRawText.isNullOrEmpty()) return false
 
         val backupName = ".${path.name}.bak.${backupStamp(nowMs)}"
-        val backupPath = path.parent.resolve(backupName)
+        var backupPath = path.parent.resolve(backupName)
+        var collisionIndex = 1
+        while (backupPath.exists()) {
+            backupPath = path.parent.resolve("$backupName.$collisionIndex")
+            collisionIndex += 1
+        }
         backupPath.writeText(existingRawText, StandardCharsets.UTF_8)
 
         val backups = path.parent.listDirectoryEntries(".${path.name}.bak.*")
@@ -204,7 +216,7 @@ class DesktopFileOrgRepository(
     }
 
     private fun resolveExistingFile(fileId: String): Path {
-        val path = runCatching { Path.of(fileId).toAbsolutePath().normalize() }
+        val path = runCatching { Path.of(fileId).toRealPath() }
             .getOrElse { throw IllegalArgumentException("Invalid file id") }
         require(isUnderRoot(path)) { "File is outside repository root" }
         require(path.exists() && path.isRegularFile()) { "File not found" }
@@ -212,6 +224,33 @@ class DesktopFileOrgRepository(
     }
 
     private fun isUnderRoot(path: Path): Boolean = path.startsWith(rootPath)
+
+    private fun canonicalTarget(path: Path): Path {
+        val absolute = path.toAbsolutePath().normalize()
+        return if (absolute.exists()) {
+            absolute.toRealPath()
+        } else {
+            absolute.parent.toRealPath().resolve(absolute.fileName)
+        }
+    }
+
+    private fun replaceFile(source: Path, target: Path) {
+        try {
+            Files.move(
+                source,
+                target,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (atomicError: IOException) {
+            try {
+                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+            } catch (fallbackError: IOException) {
+                fallbackError.addSuppressed(atomicError)
+                throw fallbackError
+            }
+        }
+    }
 
     private fun dailyPath(date: LocalDate): Path = rootPath.resolve("$date.org")
 


### PR DESCRIPTION
## Summary

- make org and template writes atomic and enforce real-path root boundaries
- add resilient desktop root persistence when Windows Preferences access fails
- stabilize root switching, LAN sync server shutdown/restart, watcher cleanup, and pending sync cancellation
- normalize Windows root identity and improve LAN adapter selection
- include `jdk.httpserver` in the packaged runtime
- exercise normal root initialization and HTTPS server startup in Windows packaged-runtime smoke tests

## Root cause

The packaged runtime omitted the Java HTTP server module, while root opening coupled local file initialization to LAN sync startup. Windows-specific file locking, registry access, path casing, fixed-port rebinding, and non-atomic writes exposed additional failure and recovery paths.

## Impact

The desktop app can open and switch roots even when LAN sync cannot start, avoids partial org/template writes, preserves root settings without relying solely on the registry, and validates the installed runtime rather than only installer layout.

## Validation

- `./gradlew.bat :desktopApp:test :shared:jvmTest`
- `./scripts/desktop-smoke-test.ps1 -SkipBuild -RuntimeOnly -ProcessTimeoutSeconds 45`
- `./gradlew.bat :desktopApp:packageMsi -Pdesktop.version=0.0.7`
