### PR TITLE
Adopt stable SemVer and disable daily instrumentation schedule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- Describe the user-visible effect and the reason for the change. -->
+
+## Version impact
+
+Select exactly one:
+
+- [ ] `major` — requires migration or breaks compatibility with supported releases
+- [ ] `minor` — adds backward-compatible functionality
+- [ ] `patch` — backward-compatible fix
+- [ ] `none` — no released-product impact
+
+Compatibility considered:
+
+- [ ] Android/Desktop sync and supported old peers
+- [ ] Pairing, envelope, or other wire formats
+- [ ] Database schemas and migrations
+- [ ] Org files and persisted credentials, identity, or settings
+- [ ] CLI or documented user-facing behavior
+
+## Changelog
+
+- [ ] Updated `CHANGELOG.md` under `Unreleased`, or the version impact is `none`
+
+## Verification
+
+<!-- List tests and manual checks performed. -->

--- a/.github/workflows/android-instrumentation.yml
+++ b/.github/workflows/android-instrumentation.yml
@@ -2,8 +2,6 @@ name: Android Instrumentation Tests
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 18 * * *"
   pull_request:
   push:
     branches:
@@ -19,7 +17,7 @@ concurrency:
 jobs:
   android-test-api34:
     name: Android Instrumentation Tests (API 34)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -62,7 +60,7 @@ jobs:
 
   android-test-api35:
     name: Android Instrumentation Tests (API 35)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -37,20 +37,32 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
-          SEMVER='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          SEMVER='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           [[ "$TAG" =~ $SEMVER ]] || {
-            echo "::error::Release tag must be SemVer (for example v1.2.3 or v1.2.3-rc.1)"
+            echo "::error::Release tag must be vMAJOR.MINOR.PATCH (for example v1.2.3)"
             exit 1
           }
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-          [[ "$TAG" == *-* ]] && IS_PRERELEASE=true || IS_PRERELEASE=false
-          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release tag
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.release.outputs.tag }}
+
+      - name: Verify tag matches the product version
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED_VERSION=$(sed -n 's/^orgclock\.version=//p' gradle.properties)
+          test -n "$EXPECTED_VERSION" || {
+            echo "::error::orgclock.version is missing from gradle.properties"
+            exit 1
+          }
+          test "$EXPECTED_VERSION" = "${{ steps.release.outputs.version }}" || {
+            echo "::error::Tag version ${{ steps.release.outputs.version }} does not match gradle.properties ($EXPECTED_VERSION)"
+            exit 1
+          }
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -64,7 +76,7 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x ./gradlew
-          ./gradlew --stacktrace packageDesktopCurrentOs -Pdesktop.version="${{ steps.release.outputs.version }}"
+          ./gradlew --stacktrace packageDesktopCurrentOs
 
       - name: Smoke test Windows installed runtime
         if: runner.os == 'Windows'
@@ -114,8 +126,6 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          [[ "$TAG" == *-* ]] && IS_PRERELEASE=true || IS_PRERELEASE=false
-          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Download installers
         uses: actions/download-artifact@v4
@@ -129,6 +139,6 @@ jobs:
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           generate_release_notes: true
-          prerelease: ${{ steps.release.outputs.is_prerelease }}
+          prerelease: false
           files: release-assets/*
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Notable user-visible changes are recorded here. This project follows Semantic
+Versioning, and release dates use `YYYY-MM-DD`.
+
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+Earlier release-candidate history is available in GitHub Releases and Git
+history. The next release is the stable `1.0.0` release.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,14 @@ val androidTestOrchestratorEnabled = providers.gradleProperty("orgclock.androidT
     .orNull
     ?.toBooleanStrictOrNull()
     ?: true
+val productVersion = providers.gradleProperty("orgclock.version").get().also { version ->
+    require(version.matches(Regex("(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"))) {
+        "orgclock.version must be MAJOR.MINOR.PATCH without the v prefix: $version"
+    }
+}
+val androidVersionCode = providers.gradleProperty("orgclock.versionCode").get().toInt().also { code ->
+    require(code > 0) { "orgclock.versionCode must be a positive integer" }
+}
 val debugApplicationIdSuffix = providers.gradleProperty("orgclock.debugApplicationIdSuffix")
     .orNull
     ?.trim()
@@ -35,8 +43,8 @@ android {
         applicationId = "com.example.orgclock"
         minSdk = 28
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = androidVersionCode
+        versionName = productVersion
         buildConfigField("boolean", "SYNC_CORE_INCLUDED", "true")
         buildConfigField("boolean", "SYNC_INTEGRATION_ENABLED", syncIntegrationEnabled.toString())
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,17 +1,21 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val desktopPackageVersion = providers.gradleProperty("desktop.version")
-    .orElse(providers.environmentVariable("ORG_CLOCK_DESKTOP_VERSION"))
-    .getOrElse("1.0.0")
-    .removePrefix("v")
-
-// MSI only accepts a numeric MAJOR.MINOR.BUILD version.
-val desktopMsiPackageVersion = desktopPackageVersion.substringBefore("-")
 val desktopSmokePackage = providers.gradleProperty("desktop.smoke")
     .map(String::toBoolean)
     .getOrElse(false)
+val productVersion = providers.gradleProperty("orgclock.version").get()
+val desktopPackageVersion = if (desktopSmokePackage) {
+    providers.gradleProperty("desktop.version").getOrElse(productVersion)
+} else {
+    productVersion
+}.also { version ->
+    require(version.matches(Regex("(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"))) {
+        "Desktop package version must be MAJOR.MINOR.PATCH without the v prefix: $version"
+    }
+}
 
+val desktopMsiPackageVersion = desktopPackageVersion
 val desktopTargetFormats = when {
     org.gradle.internal.os.OperatingSystem.current().isMacOsX -> arrayOf(TargetFormat.Dmg)
     org.gradle.internal.os.OperatingSystem.current().isWindows -> arrayOf(TargetFormat.Msi)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -5,13 +5,14 @@ releases.
 
 ## Product version
 
-The canonical release version is the Git tag:
+The canonical product version is `orgclock.version` in `gradle.properties`.
+Release tags add the `v` prefix:
 
 ```text
 vMAJOR.MINOR.PATCH
 ```
 
-For example, tag `v1.4.2` represents product version `1.4.2`. Android, iOS, and
+For example, property value `1.4.2` is released as tag `v1.4.2`. Android, iOS, and
 desktop builds released from the same commit use the same product version.
 
 - `MAJOR`: incompatible changes to user data, sync/network compatibility, or
@@ -34,47 +35,25 @@ Versions below `1.0.0` indicate that compatibility is not yet guaranteed.
 The first release that promises stable user-data and sync compatibility is
 `1.0.0`.
 
-## Pre-releases
+## Release versions
 
-Unstable release candidates use SemVer pre-release identifiers:
-
-```text
-v1.3.0-alpha.1
-v1.3.0-beta.1
-v1.3.0-rc.1
-```
-
-Increment the numeric suffix for each candidate. A stable release removes the
-suffix. Build metadata such as `+sha.abc1234` may identify local or CI builds,
-but it does not change release precedence and should not be used for public
-release tags.
-
-Pushing a pre-release tag runs the `Release Desktop Installers` workflow. The
-workflow builds the Windows and Linux installers and publishes the associated
-GitHub Release with its **Pre-release** flag enabled.
-
-For example, create and push the first `1.0.0` release candidate with:
-
-```bash
-git tag -a v1.0.0-rc.1 -m "Org Clock v1.0.0-rc.1"
-git push origin v1.0.0-rc.1
-```
-
-Do not move or reuse a published pre-release tag. Fix the problem and increment
-the suffix, for example from `rc.1` to `rc.2`.
+New releases use only stable `MAJOR.MINOR.PATCH` versions. Pre-release suffixes
+such as `-alpha`, `-beta`, and `-rc` are not used or accepted by the release
+workflow. Existing `v1.0.0-rc.1` through `v1.0.0-rc.5` tags remain immutable
+historical records; the first release under this policy is `v1.0.0`.
 
 ## Platform build numbers
 
 Store-facing build numbers are not part of SemVer:
 
 - Android `versionName` is the product version; `versionCode` is a
-  monotonically increasing integer.
+  monotonically increasing integer stored as `orgclock.versionCode` in
+  `gradle.properties`. Increment it for every Android release build, including
+  pre-releases and rebuilds.
 - iOS `CFBundleShortVersionString` is the product version;
   `CFBundleVersion` is a monotonically increasing integer.
-- Desktop package versions are derived from the Git tag without the leading
-  `v`. Windows MSI metadata uses the numeric `MAJOR.MINOR.PATCH` portion because
-  MSI does not accept SemVer pre-release identifiers; the Git tag, GitHub
-  Release, and installer filename retain the complete pre-release version.
+- Desktop package versions use `orgclock.version`, including Windows MSI
+  metadata.
 
 Rebuilding an existing product version for a store may increment only the
 platform build number. It must not replace or move an existing Git tag or
@@ -94,10 +73,33 @@ versions.
 
 ## Release procedure
 
-1. Select the next version from changes since the latest release.
-2. Update platform product versions and monotonically increasing build numbers.
-3. Verify release builds and migration/sync compatibility.
-4. Create an annotated `vMAJOR.MINOR.PATCH` tag, or a permitted pre-release tag.
-5. Push the tag. The desktop release workflow publishes generated release notes,
-   installers, and checksums; pre-release tags are marked as GitHub
-   Pre-releases.
+1. Confirm each included PR's `major`, `minor`, `patch`, or `none` classification.
+2. Select the next version from changes recorded under `CHANGELOG.md`'s
+   `Unreleased` section.
+3. Update `orgclock.version` and increment `orgclock.versionCode` in
+   `gradle.properties`.
+4. Rename the changelog's `Unreleased` entries to `VERSION - YYYY-MM-DD` and add
+   a new empty `Unreleased` section.
+5. Verify release builds and migration/sync compatibility using the checklist below.
+6. Commit the release as `chore(release): VERSION`.
+7. Create an annotated `vMAJOR.MINOR.PATCH` tag.
+8. Push the tag. The desktop release workflow verifies that the tag matches
+   `orgclock.version`, then publishes generated release notes, installers, and
+   checksums as a stable GitHub Release.
+
+## Compatibility checklist
+
+Before selecting the increment, check whether the release remains compatible
+with every supported released version across:
+
+- Android/Desktop sync protocol and old-peer communication
+- pairing invitations, envelopes, signatures, and other wire formats
+- Room/SQLite schemas, automatic migrations, and rollback or backup behavior
+- org-file parsing and writing
+- credentials, identities, trust state, and settings persisted on disk
+- CLI and documented user-visible behavior
+
+If old data can be migrated automatically and supported old peers still
+interoperate, the change can normally be `MINOR` or `PATCH`. Requiring users to
+migrate manually, invalidating stored identity/credentials, or intentionally
+dropping old-peer interoperability is a `MAJOR` change after 1.0.0.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ android.nonTransitiveRClass=true
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.applyDefaultHierarchyTemplate=false
+orgclock.version=1.0.0
+orgclock.versionCode=6


### PR DESCRIPTION
## Summary

- remove the daily Android instrumentation schedule while preserving manual, pull request, and main-push execution
- make `gradle.properties` the single source of truth for the stable product version
- align Android and Desktop versions at `1.0.0`
- reject `alpha`, `beta`, and `rc` release tags
- add changelog and pull request version-impact conventions
- document the project-specific compatibility and release policy

## Why

The scheduled instrumented tests were failing repeatedly and consuming GitHub Actions minutes. Product versions were also duplicated across Android, Desktop, tags, and release automation, with existing values not matching the latest release history.

## Impact

Android now builds with `versionName=1.0.0` and `versionCode=6`. Desktop packages use the same product version. Future releases must use stable `vMAJOR.MINOR.PATCH` tags that match `orgclock.version` in `gradle.properties`.

Existing `v1.0.0-rc.1` through `v1.0.0-rc.5` tags remain unchanged as historical records.

## Version impact

- [ ] `major`
- [ ] `minor`
- [ ] `patch`
- [x] `none` — release-process and CI changes only

## Verification

- `./gradlew.bat help`
- `./gradlew.bat :app:processDebugMainManifest`
- verified generated Android manifest contains `versionName=1.0.0` and `versionCode=6`
- `git diff --check`
- verified the instrumentation workflow no longer contains a schedule or cron trigger
